### PR TITLE
fix(workspace-create): route through bootstrap_workspace RPC for atomic creation

### DIFF
--- a/src/services/workspaceService.ts
+++ b/src/services/workspaceService.ts
@@ -320,13 +320,15 @@ export const workspaceService = {
 
   /**
    * Creates a new primary (billed) workspace owned by the currently authenticated user.
-   * Automatically inserts the owner as a workspace_member with role 'owner' and
-   * starts a 30-day Pulse Team trial. Used for first-time users only — additional
-   * workspaces under an existing owner go through `createChildWorkspace`.
+   * The workspaces row and the owner workspace_members row are written together in the
+   * bootstrap_workspace SECURITY DEFINER RPC's single plpgsql transaction, so a
+   * partial-creation orphan can't happen. Then starts a 30-day Pulse Team trial; if
+   * that fails, the workspace is hard-deleted (FK CASCADE removes the member row).
+   *
+   * Used for first-time users only — additional workspaces under an existing owner
+   * go through `createChildWorkspace`.
    */
   async createWorkspace(name: string, description?: string, plan: WorkspacePlan = 'team'): Promise<Workspace> {
-    const userId = await getCurrentUserId();
-
     const baseSlug = name
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
@@ -334,44 +336,38 @@ export const workspaceService = {
       .slice(0, 40) || 'workspace';
     const slug = `${baseSlug}-${Date.now().toString(36)}`;
 
-    const { data: workspace, error: workspaceError } = await supabase
+    const { data: workspaceId, error: rpcError } = await supabase.rpc('bootstrap_workspace', {
+      p_name:        name,
+      p_slug:        slug,
+      p_description: description ?? null,
+      p_plan:        plan,
+    });
+
+    assertNoError(rpcError, 'createWorkspace — bootstrap_workspace RPC');
+
+    if (!workspaceId) {
+      throw new Error('[workspaceService] createWorkspace: RPC returned no workspace id');
+    }
+
+    // Fetch the just-created row to return the full Workspace shape. RLS allows
+    // this because the bootstrap RPC has already inserted the caller as the owner.
+    const { data: workspace, error: fetchError } = await supabase
       .from('workspaces')
-      .insert({
-        name,
-        slug,
-        description: description ?? null,
-        owner_id: userId,
-        plan,
-        parent_workspace_id: null,
-      })
-      .select()
+      .select('*')
+      .eq('id', workspaceId)
       .single();
 
-    assertNoError(workspaceError, 'createWorkspace — insert workspace');
+    assertNoError(fetchError, 'createWorkspace — fetch new workspace row');
 
-    const { error: memberError } = await supabase
-      .from('workspace_members')
-      .insert({
-        workspace_id: workspace.id,
-        user_id: userId,
-        role: 'owner',
-        invited_by: null,
-      });
-
-    assertNoError(memberError, 'createWorkspace — insert owner member');
-
-    // Hard-fail on trial bootstrap. A workspace without an entitlements row paints
-    // TrialExpiredBlock on first navigation, which is worse than rolling back here.
-    // If the trial RPC errors we drop the workspace + membership we just created
-    // so the next attempt starts clean instead of zombieing the org.
+    // Start the 30-day trial. On failure, hard-delete the workspace; FK CASCADE
+    // takes the workspace_members row with it, so a single DELETE is the rollback.
     try {
       const billingService = (await import('./billingService')).default;
-      await billingService.startPulseTeamTrial(workspace.id);
+      await billingService.startPulseTeamTrial(workspaceId as string);
     } catch (e) {
       console.error('[workspaceService] startPulseTeamTrial failed; rolling back workspace', e);
       try {
-        await supabase.from('workspace_members').delete().eq('workspace_id', workspace.id);
-        await supabase.from('workspaces').delete().eq('id', workspace.id);
+        await supabase.from('workspaces').delete().eq('id', workspaceId);
       } catch (rollbackErr) {
         console.error('[workspaceService] Rollback also failed', rollbackErr);
       }

--- a/supabase/migrations/20260514000008_codify_bootstrap_workspace.sql
+++ b/supabase/migrations/20260514000008_codify_bootstrap_workspace.sql
@@ -1,0 +1,75 @@
+-- ============================================================
+-- MIGRATION: 20260514000008_codify_bootstrap_workspace.sql
+-- PURPOSE:   Codify the public.bootstrap_workspace SECURITY DEFINER
+--            function that already exists in production but is NOT
+--            tracked in the migration tree.  Discovered during the
+--            2026-05-14 audit; see #46.
+--
+--            grep -r bootstrap_workspace supabase/migrations/ → 0 files
+--            but pg_proc shows the function live in prod (added via
+--            the dashboard or a long-forgotten one-off).  This puts
+--            it under version control so future devs can read the
+--            contract.
+--
+--            Function body is captured verbatim from the live function
+--            definition (queried via pg_get_functiondef on
+--            ucaeuszgoihoyrvhewxk).  CREATE OR REPLACE so the migration
+--            is idempotent against the live definition that already
+--            exists.
+--
+--            The function guarantees atomicity: both the workspaces
+--            insert and the workspace_members owner-row insert happen
+--            in the same transaction (the plpgsql function body), so
+--            if either fails the workspace never appears half-created.
+--            This is the fix for the orphan workspace pattern that
+--            #39's cleanup found (an empty 'Dev Team' workspace with
+--            no member rows that #46's TS callsite produced).
+--
+-- ISSUE:     #46  (Pulse-1)  — Phase 1: codify the RPC
+-- PLAN DOC:  N/A (issue-only)
+-- ============================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.bootstrap_workspace(
+  p_name        text,
+  p_slug        text,
+  p_description text DEFAULT NULL,
+  p_plan        text DEFAULT 'free',
+  p_id          uuid DEFAULT gen_random_uuid()
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  INSERT INTO public.workspaces (id, name, slug, description, owner_id, plan)
+  VALUES (p_id, p_name, p_slug, p_description, v_user_id, p_plan);
+
+  INSERT INTO public.workspace_members (workspace_id, user_id, role)
+  VALUES (p_id, v_user_id, 'owner');
+
+  RETURN p_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.bootstrap_workspace(text, text, text, text, uuid) IS
+  'Atomic workspace creation: inserts the workspaces row + the owner workspace_members row '
+  'in the same transaction (the plpgsql function body).  SECURITY DEFINER so it bypasses '
+  'the workspace_members_insert RLS chicken-and-egg (the new row IS the bootstrap caller).';
+
+-- Match the live GRANTs.  authenticated calls from the client; anon
+-- and service_role retained for parity with the existing live state
+-- (auth.uid() check inside still gates anon to NULL → exception).
+REVOKE ALL  ON FUNCTION public.bootstrap_workspace(text, text, text, text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bootstrap_workspace(text, text, text, text, uuid)
+  TO anon, authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
Closes #46.

## Summary

Two changes that together close the orphan-by-construction risk we hand-cleaned during #39:

1. **Codify `public.bootstrap_workspace`** as `supabase/migrations/20260514000008_codify_bootstrap_workspace.sql`. The function already existed in prod (we used `pg_get_functiondef` on `ucaeuszgoihoyrvhewxk` to capture the live body verbatim), but `grep -r bootstrap_workspace supabase/migrations/` returned zero — schema drift between the migration tree and live. The CREATE OR REPLACE in the new migration is idempotent against the existing definition; no behavioural change to live.

2. **Rewrite `workspaceService.createWorkspace`** to call the RPC instead of doing two separate client-side inserts. The RPC body runs both inserts (`workspaces` + the owner `workspace_members` row) in a single plpgsql transaction, so a step-2 failure rolls step-1 back automatically.

| Before | After |
|---|---|
| `INSERT workspaces` → `assertNoError` → `INSERT workspace_members` → `assertNoError`. Step-2 failure leaves an orphan workspace. | `supabase.rpc('bootstrap_workspace', {...})` returns the new workspace_id; both rows atomic. Then fetch the row for the return type. |
| Trial-bootstrap rollback: manual `DELETE workspace_members` then `DELETE workspaces`. | Trial-bootstrap rollback: single `DELETE workspaces`; FK CASCADE handles the member row. |

## Verification

- Live `pg_proc` query confirms the codified migration's body, defaults (`p_description=NULL`, `p_plan='free'`, `p_id=gen_random_uuid()`), grants (`postgres, anon, authenticated, service_role`), and SECURITY DEFINER all match what was already live.
- Behavioural probe: calling `bootstrap_workspace('...', '...')` from a context where `auth.uid() IS NULL` raises `sqlstate P0001 "Not authenticated"`; the workspaces row count is unchanged pre/post. (Service-role MCP context can't impersonate `auth.uid()`, so the happy-path browser smoke is a post-merge manual test.)

## Manual test plan (post-merge, browser)

- [ ] Sign up a fresh account → first workspace gets created with both the `workspaces` row AND a `workspace_members` row with `role='owner'`.
- [ ] Trigger a forced trial-bootstrap failure (e.g. revoke EXECUTE on `start_pulse_team_trial` for `authenticated`) → workspace creation rolls back; no orphan.
- [ ] Check `workspace_members` row count after a successful creation increments by 1.

## Out of scope

- `createChildWorkspace` (line ~394) uses a different RPC (`create_child_workspace`) which is already atomic. No changes needed.
- The bootstrap RPC's broad GRANT (`anon, authenticated, service_role`) is preserved as-is; the `auth.uid() IS NULL` check inside still gates anon callers. Tightening to `authenticated, service_role` only could land as a follow-up if you want defense-in-depth.

## Memory implications

The drifted-RPC pattern (function exists in pg_proc but not in any migration file) is worth a periodic audit. Suggested SQL for catching others:

```sql
SELECT proname FROM pg_proc p
JOIN pg_namespace n ON n.oid = p.pronamespace
WHERE n.nspname = 'public'
  AND p.prokind = 'f'
  AND p.proname NOT IN (...known catalog of in-tree functions...);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)