### PR TITLE
feat(team-settings): gate Groups card behind feature flag until consumer ships

### DIFF
--- a/src/components/settings/TeamSettings.tsx
+++ b/src/components/settings/TeamSettings.tsx
@@ -8,6 +8,7 @@ import { GroupsManagementCard } from './team/GroupsManagementCard';
 import { RolePermissionsMatrixCard } from './team/RolePermissionsMatrixCard';
 import { SettingsCard } from './shared/SettingsCard';
 import { MonoLabel } from './shared/MonoLabel';
+import { useFeatureFlag } from '../../lib/featureFlags';
 
 interface TeamSettingsProps {
   userId: string;
@@ -18,6 +19,10 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
   const { currentWorkspace, members } = useWorkspaceData();
   const { refreshMembers } = useWorkspaceActions();
   const { isOwner, isAdmin, canManageMembers } = useWorkspacePermissions();
+  // Groups card is gated behind a flag until #42 phase 5 lands a real read
+  // consumer (group_grants → mentions / routing / channel ACL). Dev override:
+  // ?ff_workspaceGroups=on (also persists to localStorage for that browser).
+  const showGroups = useFeatureFlag('workspaceGroups', userId);
 
   const [pendingInvites, setPendingInvites] = useState<WorkspaceInvite[]>([]);
   const [inviteEmail, setInviteEmail] = useState('');
@@ -314,8 +319,8 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
         </div>
       </SettingsCard>
 
-      {/* Groups & departments */}
-      {workspaceId && (
+      {/* Groups & departments — see showGroups flag declaration above. */}
+      {workspaceId && showGroups && (
         <GroupsManagementCard
           workspaceId={workspaceId}
           members={members}

--- a/src/components/settings/team/GroupsManagementCard.tsx
+++ b/src/components/settings/team/GroupsManagementCard.tsx
@@ -197,7 +197,9 @@ export const GroupsManagementCard: React.FC<Props> = ({ workspaceId, members, is
       </div>
 
       <p className="text-xs text-zinc-500 dark:text-zinc-400">
-        Organize members into groups for permissions, mentions, and reporting. Members can belong to multiple groups.
+        Tags for organising members. Coming soon: mention routing,
+        notification rules, and channel access derived from group
+        membership.
       </p>
 
       {/* Create form */}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -119,6 +119,24 @@ const featureFlagsConfig: FeatureFlagConfig = {
     version: '0.1.0'
   },
 
+  // Team Settings → Groups card.
+  //
+  // The workspace_groups + workspace_group_members schema is real (RLS,
+  // CRUD service methods, full UI), but the *read side* is absent — no
+  // mention parser, no notification router, no channel ACL, no RLS
+  // policy consumes workspace_group_members.  The card's promise of
+  // "groups for permissions, mentions, and reporting" is fiction until
+  // #42 phase 5 (group_grants table + extended user_has_permission)
+  // lands a consumer.  Hidden in production to avoid promising features
+  // that don't exist; dev override is `?ff_workspaceGroups=on`.
+  workspaceGroups: {
+    enabled: false,
+    rolloutPercentage: 0,
+    targetUsers: ['internal'],
+    description: 'PAUSED — Groups CRUD UI; no read consumer until #42 ships group_grants',
+    version: '0.1.0'
+  },
+
   // Phase 5e — ⚠️ PAUSED as of 2026-04-27.
   //
   // The v2 entry exists as parallel-rebuild scaffolding but has a


### PR DESCRIPTION
Closes #43.

## Summary

The `workspace_groups` + `workspace_group_members` schema and CRUD UI exist, but there's no read consumer — no mention parser, notification router, channel ACL, or RLS policy reads `workspace_group_members`. The card's previous copy advertised "groups for permissions, mentions, and reporting" — fiction until #42 phase 5 lands `group_grants` + extends `user_has_permission()`.

Three small changes, 28 lines total:

1. **`src/lib/featureFlags.ts`** — adds the `workspaceGroups` flag entry (`enabled: false`, `rolloutPercentage: 0`), matching the existing `proposalMode` + `pulseMessagesV2` "scaffolded but disabled" precedents. Dev override is `?ff_workspaceGroups=on` via the existing `readDevOverride` helper.
2. **`src/components/settings/TeamSettings.tsx`** — hoists `const showGroups = useFeatureFlag('workspaceGroups', userId)` at the top of the component, wraps `<GroupsManagementCard />` in `{workspaceId && showGroups && ...}`. Hook called unconditionally.
3. **`src/components/settings/team/GroupsManagementCard.tsx`** — copy change from "Organize members into groups for permissions, mentions, and reporting" to "Tags for organising members. Coming soon: mention routing, notification rules, and channel access derived from group membership." Defense-in-depth: even if a dev flips the flag on, the card no longer over-promises.

## What stays

- The `workspace_groups` table, RLS policies, all `workspaceService.{createGroup, updateGroup, addGroupMember, removeGroupMember, getGroups, getGroupMembers}` methods, and the `GroupsManagementCard` component itself. They return automatically when the flag is flipped — no resurrection PR needed.

## Test plan

- [ ] In a fresh prod-config build, navigate to Settings → Team → confirm the Groups card does NOT render
- [ ] In the same build, append `?ff_workspaceGroups=on` to the URL → reload → confirm the card now renders (and persists on subsequent navigations via localStorage)
- [ ] `?ff_workspaceGroups=off` (or clearing the localStorage key) returns to the hidden state

## Notable

This PR was scope-cleaned mid-flight. An unrelated deep-link/focus block (`?focus=invite` scroll-and-highlight) lives uncommitted in `TeamSettings.tsx`'s working tree from prior session work. It's intentionally NOT included here — staged as 7 insertions / 2 deletions on `TeamSettings.tsx`, not 37 lines. The deep-link work persists in the working tree and can land in a separate commit/PR (likely under #41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)