### PR TITLE
feat(team-settings): UX bundle phase 1 (deep-link, copy-link, transfer hint, groups empty-state)

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -120,6 +120,36 @@ const Settings: React.FC<SettingsProps> = ({ user, isDarkMode, toggleTheme, init
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  // Cross-section navigation via custom event.  Components inside any
+  // settings section can dispatch
+  //   window.dispatchEvent(new CustomEvent('pulse:settings-navigate', {
+  //     detail: { section: 'workspace', focus: 'transfer' }
+  //   }))
+  // to switch sections AND drop a `?focus=<key>` param the destination
+  // section can read on mount (mirrors the ?focus=invite pattern in
+  // TeamSettings.tsx).  Decouples team-settings owner-row "Transfer
+  // ownership →" link from workspace-settings without URL routing.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const ce = e as CustomEvent<{ section?: string; focus?: string }>;
+      const section = ce.detail?.section;
+      const focus   = ce.detail?.focus;
+      if (!section) return;
+      setActiveSection(section);
+      if (focus) {
+        const params = new URLSearchParams(window.location.search);
+        params.set('focus', focus);
+        window.history.replaceState(
+          {},
+          '',
+          `${window.location.pathname}?${params.toString()}`,
+        );
+      }
+    };
+    window.addEventListener('pulse:settings-navigate', handler);
+    return () => window.removeEventListener('pulse:settings-navigate', handler);
+  }, []);
+
   // Deep-link support: ?settings=<sectionId>
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);

--- a/src/components/settings/TeamSettings.tsx
+++ b/src/components/settings/TeamSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useWorkspaceData, useWorkspaceActions, useWorkspacePermissions } from '../../contexts/WorkspaceContext';
 import { workspaceService, WorkspaceMember, WorkspaceInvite, WORKSPACE_PLAN_LABELS, WORKSPACE_PLAN_LIMITS } from '../../services/workspaceService';
-import { Loader2, Mail, Send, Users, Shield, UserMinus, ChevronDown, Clock, X, RotateCcw } from 'lucide-react';
+import { Loader2, Mail, Send, Users, Shield, UserMinus, ChevronDown, Clock, X, RotateCcw, Copy, Check } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BulkInviteCard } from './team/BulkInviteCard';
 import { GroupsManagementCard } from './team/GroupsManagementCard';
@@ -30,6 +30,8 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
   const [isInviting, setIsInviting] = useState(false);
   const [roleDropdownOpen, setRoleDropdownOpen] = useState<string | null>(null);
   const [isLoadingInvites, setIsLoadingInvites] = useState(false);
+  // Which pending-invite row was just copied? Drives the 1.5s Check icon.
+  const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null);
 
   // Deep-link focus (?focus=invite) — scroll + highlight the invite form
   // and put the cursor in the email field.
@@ -127,6 +129,21 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
       await refreshMembers();
     } catch {
       toast.error('Failed to remove member');
+    }
+  };
+
+  const handleCopyInviteLink = async (invite: WorkspaceInvite) => {
+    const url = workspaceService.getInviteLink(invite.token);
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedInviteId(invite.id);
+      toast.success('Invite link copied');
+      setTimeout(() => setCopiedInviteId((prev) => (prev === invite.id ? null : prev)), 1500);
+    } catch {
+      toast.error('Could not copy. Long-press to copy manually:');
+      // Some browsers block clipboard on insecure contexts. Show the URL inline
+      // via a second toast so the user can still grab it.
+      toast(url, { duration: 8000 });
     }
   };
 
@@ -251,13 +268,26 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
                     </p>
                   </div>
                 </div>
-                <button
-                  type="button"
-                  className="text-xs font-medium text-red-500 hover:text-red-600 flex items-center gap-1"
-                  onClick={() => handleRevokeInvite(invite)}
-                >
-                  <X className="w-3 h-3" /> Revoke
-                </button>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 flex items-center gap-1"
+                    onClick={() => handleCopyInviteLink(invite)}
+                    aria-label={`Copy invite link for ${invite.email}`}
+                  >
+                    {copiedInviteId === invite.id
+                      ? <><Check className="w-3 h-3" /> Copied</>
+                      : <><Copy className="w-3 h-3" /> Copy link</>}
+                  </button>
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-red-500 hover:text-red-600 flex items-center gap-1"
+                    onClick={() => handleRevokeInvite(invite)}
+                    aria-label={`Revoke invite for ${invite.email}`}
+                  >
+                    <X className="w-3 h-3" /> Revoke
+                  </button>
+                </div>
               </div>
             ))}
           </div>

--- a/src/components/settings/TeamSettings.tsx
+++ b/src/components/settings/TeamSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useWorkspaceData, useWorkspaceActions, useWorkspacePermissions } from '../../contexts/WorkspaceContext';
 import { workspaceService, WorkspaceMember, WorkspaceInvite, WORKSPACE_PLAN_LABELS, WORKSPACE_PLAN_LIMITS } from '../../services/workspaceService';
 import { Loader2, Mail, Send, Users, Shield, UserMinus, ChevronDown, Clock, X, RotateCcw } from 'lucide-react';
@@ -30,6 +30,32 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
   const [isInviting, setIsInviting] = useState(false);
   const [roleDropdownOpen, setRoleDropdownOpen] = useState<string | null>(null);
   const [isLoadingInvites, setIsLoadingInvites] = useState(false);
+
+  // Deep-link focus (?focus=invite) — scroll + highlight the invite form
+  // and put the cursor in the email field.
+  const inviteCardRef = useRef<HTMLDivElement>(null);
+  const inviteEmailInputRef = useRef<HTMLInputElement>(null);
+  const [inviteFocused, setInviteFocused] = useState(false);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('focus') !== 'invite') return;
+
+    setInviteFocused(true);
+    const scrollT = setTimeout(() => {
+      inviteCardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setTimeout(() => inviteEmailInputRef.current?.focus(), 400);
+    }, 50);
+    const fadeT = setTimeout(() => setInviteFocused(false), 3000);
+
+    params.delete('focus');
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`,
+    );
+
+    return () => { clearTimeout(scrollT); clearTimeout(fadeT); };
+  }, []);
 
   const workspaceId = currentWorkspace?.id;
   const plan = currentWorkspace?.plan ?? 'free';
@@ -150,10 +176,18 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
 
       {/* Invite Form — admin+ only */}
       {canManageMembers && (
+      <div
+        ref={inviteCardRef}
+        className="scroll-mt-4 rounded-2xl transition-shadow"
+        style={{
+          boxShadow: inviteFocused ? '0 0 0 3px rgba(244, 63, 94, 0.45)' : 'none',
+        }}
+      >
         <SettingsCard>
           <MonoLabel className="mb-6">Invite New Member</MonoLabel>
           <div className="flex gap-2">
             <input
+              ref={inviteEmailInputRef}
               type="email"
               value={inviteEmail}
               onChange={(e) => setInviteEmail(e.target.value)}
@@ -182,6 +216,7 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
             </button>
           </div>
         </SettingsCard>
+      </div>
       )}
 
       {/* Bulk invite — admin+ only */}

--- a/src/components/settings/TeamSettings.tsx
+++ b/src/components/settings/TeamSettings.tsx
@@ -358,9 +358,31 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
                       )}
                     </>
                   ) : (
-                    <span className={`px-2.5 py-1 text-xs rounded-full font-medium ${roleColors[member.role]}`}>
-                      {member.role}
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className={`px-2.5 py-1 text-xs rounded-full font-medium ${roleColors[member.role]}`}>
+                        {member.role}
+                      </span>
+                      {/* Surface "Transfer ownership" on the owner's own row.
+                          Without this hint, an owner who wants to leave has
+                          to discover that (a) they can't remove themselves
+                          from Team, (b) ownership transfer lives in Workspace
+                          settings. Fires a custom event the Settings shell
+                          listens for. */}
+                      {isMemberOwner && isCurrentUser && isOwner && (
+                        <button
+                          type="button"
+                          onClick={() => window.dispatchEvent(
+                            new CustomEvent('pulse:settings-navigate', {
+                              detail: { section: 'workspace', focus: 'transfer' },
+                            }),
+                          )}
+                          className="text-xs font-medium text-rose-500 hover:text-rose-600 dark:text-rose-400 dark:hover:text-rose-300"
+                          aria-label="Transfer ownership in Workspace settings"
+                        >
+                          Transfer →
+                        </button>
+                      )}
+                    </div>
                   )}
                 </div>
 

--- a/src/components/settings/team/GroupsManagementCard.tsx
+++ b/src/components/settings/team/GroupsManagementCard.tsx
@@ -22,6 +22,10 @@ interface Props {
   isAdmin: boolean;
 }
 
+// Group color palette. Stored as literal hex in workspace_groups.color so the
+// DB row is self-describing (no CSS-var leaks). The first entry mirrors
+// `--pulse-accent` from src/styles/pulse-tokens.css — keep them in sync if
+// the brand coral ever changes.
 const GROUP_COLORS = ['#f43f5e', '#f97316', '#eab308', '#22c55e', '#0ea5e9', '#8b5cf6', '#ec4899', '#64748b'];
 
 export const GroupsManagementCard: React.FC<Props> = ({ workspaceId, members, isAdmin }) => {
@@ -262,8 +266,19 @@ export const GroupsManagementCard: React.FC<Props> = ({ workspaceId, members, is
       )}
 
       {!isLoading && groups.length === 0 && !creating && (
-        <div className="py-8 text-center text-xs text-zinc-400">
-          No groups yet.{isAdmin && ' Create one above to get started.'}
+        <div className="py-10 text-center space-y-3">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">
+            No groups yet.
+          </p>
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={() => setCreating(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold text-white bg-rose-500 hover:bg-rose-600 rounded-lg transition"
+            >
+              <Plus className="w-3.5 h-3.5" /> Create your first group
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Partial fix for #41. Phase-1 lands 4 of the 12 issue-body tasks — the highest-leverage user-visible improvements that are safe and small. Remaining items are tracked at the bottom for a follow-up PR.

## Summary

| # | Commit | What |
|---|---|---|
| 1 | `be1ef61` | Deep-link focus the Invite card via `?focus=invite` (refs, scroll-into-view, 3s coral ring on focus, URL self-cleaning). Used by other parts of the app that want to land users on a specific action. |
| 2 | `6ceaef9` | Copy invite link button on every pending-invite row. 1.5s Check icon on copy. Clipboard-API fallback shows the raw URL in an 8s toast for insecure contexts. aria-labels on both Copy + Revoke. Closes the audit's promise/delivery gap (the email-failure toast told users to copy the link from Pending Invites, but no button existed). |
| 3 | `999c31d` | Transfer ownership link on owner's own row + new `pulse:settings-navigate` CustomEvent that the Settings shell listens for and uses to switch sections + drop a `?focus=<key>` URL param. Closes the worst single discoverability gap (an owner who wanted to leave had no inline hint that they had to transfer first). |
| 4 | `1d71624` | Groups card empty-state CTA — primary "+ Create your first group" button instead of dimmed "No groups yet" text. Plus a comment on the `GROUP_COLORS` palette documenting why the first entry mirrors `--pulse-accent` literally (DB stores hex, not CSS vars). |

## Verification

All four commits are surgical edits that touch only Team-Settings-adjacent files:

| File | Lines changed |
|---|---|
| `src/components/settings/TeamSettings.tsx` | +102 / −12 |
| `src/components/settings/team/GroupsManagementCard.tsx` | +17 / −2 |
| `src/components/Settings.tsx` | +30 / 0 |

No DB / RLS / service-method changes.

## Test plan (post-merge, browser)

- [ ] `/settings?settings=team&focus=invite` lands on the Team tab with the Invite card highlighted + email input focused. URL self-cleans the `focus` param.
- [ ] On a pending invite row: Copy link button → clipboard contains the canonical invite URL → 1.5s Check feedback → toast "Invite link copied".
- [ ] As workspace owner: own row shows "Transfer →" link next to the role badge; click switches to Workspace tab and lands on a URL with `?focus=transfer`.
- [ ] As an admin (not owner): own row's "owner" badge is absent (because admin's badge says "admin"); other owners' rows do NOT show "Transfer →" (only the viewer-is-owner case).
- [ ] As a non-admin: no actions appear on the Members list; role badge is a static span. No regression.
- [ ] In dev with `?ff_workspaceGroups=on`: Groups card shows. Empty workspace → "Create your first group" primary CTA. Click → create form expands.

## Remaining tasks from #41 (deferred to follow-up PR)

- **C1**: promote seat counter to meter with `Upgrade` CTA when usage > 70%
- **C3-merge**: collapse single-invite + Bulk Invite into one card with a "Paste many" toggle
- **C3-files**: CSV file upload + drag-drop on Bulk Invite
- **C4**: role popover at point-of-choice (5 key permissions on hover of the role select)
- **C6-promote**: reorder — Members card above Invites
- **C8b**: replace native `window.confirm` calls (remove/revoke) with the project's modal pattern
- **F1**: capture `workspace_id` at mutation start; disable workspace switcher during mid-mutation

These need design decisions (seat meter shape, modal vocabulary, page-reorder ordering) that I'd rather discuss before committing to a particular implementation. Filing as a phase-2 PR makes sense once those are nailed down.

## Side notes

- `Settings.tsx` gained a small `pulse:settings-navigate` event listener that any settings sub-component can dispatch to switch sections without coupling to URL routing. Decoupled, type-safe via `CustomEventInit<{ section?: string; focus?: string }>`.
- `WorkspaceSettings.tsx` does NOT yet have a `?focus=transfer` deep-link useEffect — that's a logical companion to commit 3 and a clean one-line addition for the phase-2 PR. The owner still lands on the Workspace tab and sees the Transfer card; they just don't get auto-scrolled to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)