### PR TITLE
feat(workspace-settings): scroll/highlight on ?focus=transfer deep-link (#41)

### DIFF
--- a/src/components/settings/WorkspaceSettings.tsx
+++ b/src/components/settings/WorkspaceSettings.tsx
@@ -38,28 +38,41 @@ export const WorkspaceSettings: React.FC = () => {
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const avatarInputRef = useRef<HTMLInputElement>(null);
 
+  // Transfer state (declared early so the focus useEffect below can
+  // auto-expand the form when ?focus=transfer deep-links into this section).
+  const [showTransfer, setShowTransfer] = useState(false);
+
   // Refs + highlight state for deep-linked onboarding focus
-  // (?focus=logo | auto-join | billing-contact). When the onboarding
-  // checklist deep-links here, we scroll to and visually highlight the
-  // specific card so the user doesn't have to hunt through a long settings page.
+  // (?focus=logo | auto-join | billing-contact | transfer). When another
+  // section deep-links here (onboarding checklist; Team Settings "Transfer →"
+  // on the owner's own row), scroll to and visually highlight the card so
+  // the user doesn't have to hunt through a long settings page.
   const avatarCardRef = useRef<HTMLDivElement>(null);
   const autoJoinCardRef = useRef<HTMLDivElement>(null);
   const billingContactCardRef = useRef<HTMLDivElement>(null);
-  type FocusTarget = 'logo' | 'auto-join' | 'billing-contact';
+  const transferCardRef = useRef<HTMLDivElement>(null);
+  type FocusTarget = 'logo' | 'auto-join' | 'billing-contact' | 'transfer';
   const [focusTarget, setFocusTarget] = useState<FocusTarget | null>(null);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const focus = params.get('focus');
-    if (focus !== 'logo' && focus !== 'auto-join' && focus !== 'billing-contact') return;
+    if (focus !== 'logo' && focus !== 'auto-join' && focus !== 'billing-contact' && focus !== 'transfer') return;
 
     setFocusTarget(focus);
+
+    // For `transfer`, auto-expand the collapsed transfer form so the user
+    // lands on the member select instead of a button they still need to click.
+    if (focus === 'transfer') {
+      setShowTransfer(true);
+    }
 
     const t = setTimeout(() => {
       const target =
         focus === 'logo' ? avatarCardRef.current
         : focus === 'auto-join' ? autoJoinCardRef.current
-        : billingContactCardRef.current;
+        : focus === 'billing-contact' ? billingContactCardRef.current
+        : transferCardRef.current;
       target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
       // For `logo`, open the file picker directly — the existing UI hides the
@@ -95,8 +108,7 @@ export const WorkspaceSettings: React.FC = () => {
     setAutoJoinEnabled(currentWorkspace.auto_join_enabled ?? false);
   }, [currentWorkspace?.id]);
 
-  // Transfer state
-  const [showTransfer, setShowTransfer] = useState(false);
+  // Transfer state (showTransfer declared above for focus-deep-link access)
   const [transferTargetId, setTransferTargetId] = useState('');
   const [isTransferring, setIsTransferring] = useState(false);
 
@@ -548,7 +560,20 @@ export const WorkspaceSettings: React.FC = () => {
 
       {/* Transfer Ownership — owner only */}
       {isOwner && nonOwnerMembers.length > 0 && (
+      <div
+        ref={transferCardRef}
+        className="scroll-mt-4 rounded-2xl transition-shadow"
+        style={{
+          boxShadow: focusTarget === 'transfer' ? '0 0 0 3px rgba(244, 63, 94, 0.45)' : 'none',
+        }}
+      >
         <SettingsCard className="space-y-4">
+          {focusTarget === 'transfer' && (
+            <div className="flex items-center gap-2 px-3 py-2 -mt-1 mb-1 rounded-lg bg-rose-50 dark:bg-rose-500/10 border border-rose-200 dark:border-rose-500/30 text-xs text-rose-700 dark:text-rose-300">
+              <ArrowRightLeft className="w-3.5 h-3.5" />
+              <span>Pick a member to transfer ownership to — you'll be demoted to admin once confirmed.</span>
+            </div>
+          )}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <ArrowRightLeft className="w-4 h-4 text-zinc-500" />
@@ -591,6 +616,7 @@ export const WorkspaceSettings: React.FC = () => {
             </div>
           )}
         </SettingsCard>
+      </div>
       )}
 
       {/* Audit Log — admin+ */}


### PR DESCRIPTION
## Summary

Completes the cross-section deep-link the previous phase-1 work wired up but left dangling.

[`TeamSettings.tsx:375-377`](../blob/main/src/components/settings/TeamSettings.tsx#L375-L377) (added in `999c31d`) dispatches `pulse:settings-navigate` with `{ section: 'workspace', focus: 'transfer' }` when an owner clicks **Transfer →** on their own row. [`Settings.tsx:132-151`](../blob/main/src/components/Settings.tsx#L132-L151) switches the active section to `workspace` and writes `?focus=transfer` to the URL. **But** [`WorkspaceSettings.tsx`](../blob/main/src/components/settings/WorkspaceSettings.tsx) only handled `logo | auto-join | billing-contact` — `transfer` fell through silently and the user landed at the top of a long settings page with no visual signal.

This adds `transfer` as the 4th `FocusTarget`, mirroring the existing pattern.

## Behaviour added

- `transferCardRef` wraps the Transfer SettingsCard
- On `?focus=transfer`, scroll into view + 3px rose ring + helper banner with the next-action copy ("Pick a member to transfer ownership to — you'll be demoted to admin once confirmed.")
- Auto-expands the collapsed transfer form (`setShowTransfer(true)`) so the user lands on the member `<select>`, not on a button they still need to click
- `showTransfer` state hoisted above the focus `useEffect` so the early `setShowTransfer(true)` is in scope
- Helper banner + ring auto-fade after 3s (existing behaviour, inherited)

## Behaviour preserved

- All 3 existing focus targets (`logo`, `auto-join`, `billing-contact`) unchanged
- Pulse Coral-as-Signal: rose ring/banner only present while `focusTarget !== null`
- No new deps, no new components, no new styles outside the existing inline pattern
- Single-file diff: 1 file changed, 34 insertions, 8 deletions

## Test plan

- [ ] Sign in as owner. Navigate to Settings → Team. On your own (owner) row, click "Transfer →"
- [ ] Active section switches to **Workspace**
- [ ] Page auto-scrolls to the **Transfer Ownership** card
- [ ] Rose ring appears around the card; a helper banner inside it names the next action
- [ ] The member `<select>` is visible immediately (form auto-expanded), not behind the "Transfer" button
- [ ] After ~3s the ring + banner fade out gracefully; the form stays expanded
- [ ] URL has been cleaned: `?focus=transfer` removed via `replaceState`

## Risks

- `Settings.tsx` cross-section handler is unchanged — only the receiving side learns a new key
- `nonOwnerMembers.length === 0` (owner is the only member) → Transfer card doesn't render → `transferCardRef.current` stays `null` → `scrollIntoView` is a no-op; helper banner never paints. Acceptable: no member to transfer to means the link itself shouldn't be useful

## Related

- Closes part of #41 (phase-2 cross-section deep-link)
- Predecessor phase-1 PRs: #51 (Transfer → link + Copy invite link + ?focus=invite)
- Plan doc: [`docs/plans/2026-05-15-team-mgmt-audit-continuation.md`](../blob/main/docs/plans/2026-05-15-team-mgmt-audit-continuation.md)

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)