### PR TITLE
feat(team-settings): role-aware ConfirmActionDialog replaces native confirm() (#41 C8b)

### DIFF
--- a/src/components/settings/TeamSettings.tsx
+++ b/src/components/settings/TeamSettings.tsx
@@ -7,6 +7,7 @@ import { BulkInviteCard } from './team/BulkInviteCard';
 import { GroupsManagementCard } from './team/GroupsManagementCard';
 import { RolePermissionsMatrixCard } from './team/RolePermissionsMatrixCard';
 import { RoleHelpPopover } from './team/RoleHelpPopover';
+import { ConfirmActionDialog } from './team/ConfirmActionDialog';
 import { SettingsCard } from './shared/SettingsCard';
 import { MonoLabel } from './shared/MonoLabel';
 import { useFeatureFlag } from '../../lib/featureFlags';
@@ -33,6 +34,16 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
   const [isLoadingInvites, setIsLoadingInvites] = useState(false);
   // Which pending-invite row was just copied? Drives the 1.5s Check icon.
   const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null);
+
+  // Two-step confirmation for destructive actions (member remove / invite
+  // revoke). Replaces native confirm() with a role-aware dialog so the user
+  // gets the differentiated copy DESIGN.md asks for.
+  type PendingConfirm =
+    | { kind: 'remove'; member: WorkspaceMember }
+    | { kind: 'revoke'; invite: WorkspaceInvite }
+    | null;
+  const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
 
   // Deep-link focus (?focus=invite) — scroll + highlight the invite form
   // and put the cursor in the email field.
@@ -121,16 +132,11 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
     setRoleDropdownOpen(null);
   };
 
-  const handleRemoveMember = async (member: WorkspaceMember) => {
+  // Triggers — open the confirm dialog with the right target. Execution
+  // happens in handleConfirmPending below once the user clicks through.
+  const handleRemoveMember = (member: WorkspaceMember) => {
     if (!workspaceId) return;
-    if (!confirm(`Remove ${member.name || member.email || 'this member'} from the workspace?`)) return;
-    try {
-      await workspaceService.removeMember(workspaceId, member.user_id);
-      toast.success('Member removed');
-      await refreshMembers();
-    } catch {
-      toast.error('Failed to remove member');
-    }
+    setPendingConfirm({ kind: 'remove', member });
   };
 
   const handleCopyInviteLink = async (invite: WorkspaceInvite) => {
@@ -148,19 +154,33 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
     }
   };
 
-  const handleRevokeInvite = async (invite: WorkspaceInvite) => {
-    if (!confirm(`Revoke invite for ${invite.email}?`)) return;
+  const handleRevokeInvite = (invite: WorkspaceInvite) => {
+    setPendingConfirm({ kind: 'revoke', invite });
+  };
+
+  const handleConfirmPending = async () => {
+    if (!pendingConfirm) return;
+    setIsConfirming(true);
     try {
-      // Delete the invite row directly
-      const { error } = await (await import('../../services/supabase')).supabase
-        .from('workspace_invites')
-        .delete()
-        .eq('id', invite.id);
-      if (error) throw error;
-      toast.success('Invite revoked');
-      await loadInvites();
+      if (pendingConfirm.kind === 'remove') {
+        if (!workspaceId) return;
+        await workspaceService.removeMember(workspaceId, pendingConfirm.member.user_id);
+        toast.success('Member removed');
+        await refreshMembers();
+      } else {
+        const { error } = await (await import('../../services/supabase')).supabase
+          .from('workspace_invites')
+          .delete()
+          .eq('id', pendingConfirm.invite.id);
+        if (error) throw error;
+        toast.success('Invite revoked');
+        await loadInvites();
+      }
+      setPendingConfirm(null);
     } catch {
-      toast.error('Failed to revoke invite');
+      toast.error(pendingConfirm.kind === 'remove' ? 'Failed to remove member' : 'Failed to revoke invite');
+    } finally {
+      setIsConfirming(false);
     }
   };
 
@@ -428,6 +448,51 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
           Contact your workspace admin to manage team members and invitations.
         </p>
       )}
+
+      {/* Confirm dialog — single instance, props derived from pendingConfirm.
+          Replaces two native confirm() calls (member remove + invite revoke)
+          per #41 C8b. Differentiated copy/severity per action. */}
+      <ConfirmActionDialog
+        isOpen={pendingConfirm !== null}
+        isLoading={isConfirming}
+        onCancel={() => { if (!isConfirming) setPendingConfirm(null); }}
+        onConfirm={handleConfirmPending}
+        severity={pendingConfirm?.kind === 'remove' ? 'destructive' : 'warning'}
+        title={
+          pendingConfirm?.kind === 'remove' ? 'Remove member?'
+          : pendingConfirm?.kind === 'revoke' ? 'Revoke pending invite?'
+          : ''
+        }
+        confirmLabel={
+          pendingConfirm?.kind === 'remove' ? 'Remove member'
+          : pendingConfirm?.kind === 'revoke' ? 'Revoke invite'
+          : ''
+        }
+        description={
+          pendingConfirm?.kind === 'remove' ? (
+            <>
+              <strong className="text-zinc-900 dark:text-white">
+                {pendingConfirm.member.name || pendingConfirm.member.email || 'This member'}
+              </strong>{' '}
+              will lose access to <strong>{currentWorkspace.name}</strong> immediately. Their
+              role assignments and group memberships will be removed.
+            </>
+          ) : pendingConfirm?.kind === 'revoke' ? (
+            <>
+              The pending invite for{' '}
+              <strong className="text-zinc-900 dark:text-white">{pendingConfirm.invite.email}</strong>{' '}
+              will be deleted and its link will stop working. You can send a fresh invite at any time.
+            </>
+          ) : null
+        }
+        detail={
+          pendingConfirm?.kind === 'remove'
+            ? 'They can be re-invited later — but any messages, voxes, or tasks they own stay in the workspace.'
+            : pendingConfirm?.kind === 'revoke'
+              ? 'The invitee never had access, so nothing else is affected.'
+              : undefined
+        }
+      />
     </div>
   );
 };

--- a/src/components/settings/team/ConfirmActionDialog.tsx
+++ b/src/components/settings/team/ConfirmActionDialog.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+
+export type ConfirmSeverity = 'warning' | 'destructive';
+
+interface ConfirmActionDialogProps {
+  isOpen: boolean;
+  severity: ConfirmSeverity;
+  title: string;
+  /** Short body paragraph — the *why* and *what's affected*, not a re-statement of the title. */
+  description: React.ReactNode;
+  /** Optional small note shown below the body in a soft tinted box (e.g. "they lose access to N channels"). */
+  detail?: React.ReactNode;
+  confirmLabel: string;
+  cancelLabel?: string;
+  isLoading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Reusable Yes/No confirmation dialog for destructive or cautionary actions.
+ * Replaces native `confirm()` so we get role-aware copy, dark mode, focus
+ * management, and a consistent visual language with the rest of the project.
+ *
+ * Modeled after DeleteWorkspaceDialog but without the type-name gate — that
+ * gate is right for once-per-workspace deletion, overkill for everyday
+ * actions like "remove a member" or "revoke a pending invite".
+ *
+ * Severity controls the colour theme:
+ *   - 'warning'      → amber (data is recoverable / the affected party hadn't yet joined)
+ *   - 'destructive'  → red (immediate loss of access, hard to reverse)
+ */
+export const ConfirmActionDialog: React.FC<ConfirmActionDialogProps> = ({
+  isOpen,
+  severity,
+  title,
+  description,
+  detail,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  isLoading = false,
+  onConfirm,
+  onCancel,
+}) => {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isLoading) onCancel();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isOpen, isLoading, onCancel]);
+
+  if (!isOpen) return null;
+
+  const isDestructive = severity === 'destructive';
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-zinc-950/70 backdrop-blur-sm p-4"
+      onClick={isLoading ? undefined : onCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-action-title"
+    >
+      <div
+        className="bg-white dark:bg-zinc-900 rounded-2xl shadow-2xl max-w-md w-full border border-zinc-200 dark:border-zinc-800"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-zinc-200 dark:border-zinc-800">
+          <div className="flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${
+              isDestructive ? 'bg-red-100 dark:bg-red-900/30' : 'bg-amber-100 dark:bg-amber-900/30'
+            }`}>
+              <AlertTriangle className={`w-5 h-5 ${
+                isDestructive ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'
+              }`} />
+            </div>
+            <h3 id="confirm-action-title" className="text-lg font-bold text-zinc-900 dark:text-white">
+              {title}
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            aria-label="Close dialog"
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5 space-y-3">
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            {description}
+          </p>
+          {detail && (
+            <div className={`rounded-lg p-3 border text-xs ${
+              isDestructive
+                ? 'bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-800/30 text-red-700 dark:text-red-400'
+                : 'bg-amber-50 dark:bg-amber-900/10 border-amber-200 dark:border-amber-800/30 text-amber-700 dark:text-amber-400'
+            }`}>
+              {detail}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 p-5 border-t border-zinc-200 dark:border-zinc-800">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 rounded-lg transition disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isLoading}
+            autoFocus
+            className={`px-4 py-2 text-sm font-semibold text-white rounded-lg transition disabled:opacity-40 disabled:cursor-not-allowed ${
+              isDestructive
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-amber-600 hover:bg-amber-700'
+            }`}
+          >
+            {isLoading ? 'Working...' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Removes the two native `confirm()` calls in [`TeamSettings.tsx`](../blob/main/src/components/settings/TeamSettings.tsx) (member remove + invite revoke). Native confirm has no styling, no dark-mode support, no focus management, and forces identical one-size-fits-all copy for two actions with very different consequences.

## Implementation

- **New file:** [`ConfirmActionDialog.tsx`](../blob/fix/team-settings-confirm-dialog/src/components/settings/team/ConfirmActionDialog.tsx) (~115 lines)
  - Modeled after `DeleteWorkspaceDialog` but **without** the type-name gate (that gate is right for once-per-workspace deletion, overkill for everyday actions)
  - `severity: 'warning' | 'destructive'` controls amber vs red colour theme
  - Optional `detail` prop renders a soft tinted note box below the body
- **TeamSettings refactor:** `pendingConfirm` state union (`{ kind: 'remove'; member }` | `{ kind: 'revoke'; invite }` | `null`); handlers split into trigger (open dialog) and `handleConfirmPending` (do the work). Single dialog instance, props derived from current `pendingConfirm`

## Differentiated copy (DESIGN.md ask)

| Action | Severity | Title | Body |
|---|---|---|---|
| Remove member | destructive (red) | "Remove member?" | Names member + workspace + immediate access loss + role/group reset. Detail: messages/voxes/tasks they own stay behind |
| Revoke invite | warning (amber) | "Revoke pending invite?" | Names invitee email + link deactivation + can resend freely. Detail: invitee never had access, nothing else affected |

## Accessibility

- `aria-modal`, `aria-labelledby`, `role="dialog"`
- `Escape` cancels (disabled during in-flight action)
- Outside-click cancels (disabled during in-flight action)
- Confirm button `autoFocus` (preserves "primary action by default" behaviour native confirm had)
- Cancel + close (X) disabled during the in-flight action so the user can't double-fire or close out mid-mutation

## What this is NOT

- Not a refactor of the 29 other `confirm()` sites in the codebase. Each needs its own role-aware copy; adoption is a separate follow-up
- Not a Radix/Headless UI dependency — pure Tailwind + lucide-react like every other modal in `src/components/settings/`
- Not a global confirm provider — explicit per-component dialog state keeps the data flow obvious

## Test plan

- [ ] Open Team Settings as workspace owner. The two native confirms are gone
- [ ] Click "Remove member" on a non-owner row → red dialog appears with the member's name, workspace name, and the detail note about their owned content
- [ ] Click outside the dialog → it closes; the member is not removed
- [ ] Click "Remove member" again → press `Escape` → dialog closes
- [ ] Click "Remove member" → click "Remove member" in the dialog → button shows "Working...", cancel button greys out, dialog closes on success, toast confirms
- [ ] In the Pending Invites list, click "Revoke" → amber dialog (not red) with email + the detail note about no other impact
- [ ] Same Escape/outside-click flows work
- [ ] Dark mode: red/amber tinted boxes still readable, button contrast holds
- [ ] Tab order: Cancel → Confirm (confirm autofocused). Confirm activates with Enter

## Related

- Closes part of #41 (C8b)
- Builds on #52 (deep-link), #53 (members above invite), #54 (role help popover)
- Follow-up issue worth filing: extend ConfirmActionDialog adoption across the other 29 `confirm()` sites

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)