### PR TITLE
feat(team-settings): seat meter with progressive coral threshold (#41 C1)

### DIFF
--- a/src/components/settings/TeamSettings.tsx
+++ b/src/components/settings/TeamSettings.tsx
@@ -8,6 +8,7 @@ import { GroupsManagementCard } from './team/GroupsManagementCard';
 import { RolePermissionsMatrixCard } from './team/RolePermissionsMatrixCard';
 import { RoleHelpPopover } from './team/RoleHelpPopover';
 import { ConfirmActionDialog } from './team/ConfirmActionDialog';
+import { SeatMeter } from './team/SeatMeter';
 import { SettingsCard } from './shared/SettingsCard';
 import { MonoLabel } from './shared/MonoLabel';
 import { useFeatureFlag } from '../../lib/featureFlags';
@@ -206,10 +207,13 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
         <h3><Users /> Team Management</h3>
         <p>
           Manage members and invitations for <strong>{currentWorkspace.name}</strong>.
-          <span className="ml-2 text-xs text-zinc-400">
-            {members.length} / {memberLimit} members ({WORKSPACE_PLAN_LABELS[plan]} plan)
-          </span>
         </p>
+        <SeatMeter
+          used={members.length}
+          limit={memberLimit}
+          planLabel={WORKSPACE_PLAN_LABELS[plan]}
+          canUpgrade={isOwner || isAdmin}
+        />
       </div>
 
       {/* Current Members — promoted above Invite by daily-task-priority

--- a/src/components/settings/team/SeatMeter.tsx
+++ b/src/components/settings/team/SeatMeter.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { ArrowUpRight, Infinity as InfinityIcon } from 'lucide-react';
+
+interface SeatMeterProps {
+  used: number;
+  limit: number;
+  planLabel: string;
+  /** Whether the current user can act on Upgrade (typically isOwner || isAdmin). */
+  canUpgrade?: boolean;
+}
+
+// Above this, the plan is effectively unlimited — render an "Unlimited"
+// chip instead of a useless 0.0001% bar. Mirrors WORKSPACE_PLAN_LIMITS
+// in workspaceService.ts where `team`/`growth` are 1_000_000.
+const UNLIMITED_THRESHOLD = 100_000;
+
+const CTA_THRESHOLD = 70;
+const CORAL_THRESHOLD = 90;
+
+/**
+ * Seat usage meter for Team Settings. Promotes "1 / 50 (Free plan)" from
+ * `text-xs text-zinc-400` (page's revenue lever in the smallest type)
+ * to a horizontal meter with progressive escalation:
+ *
+ *   <70%   — neutral zinc fill, no CTA
+ *   70-90% — amber fill, Upgrade CTA appears
+ *   >90%   — rose fill (Coral-As-Signal active), Upgrade CTA emphasised
+ *
+ * Upgrade CTA fires `pulse:settings-navigate` with `section: 'billing'`,
+ * matching how UsageWarningBanner / Summit / useAIErrorHandler already
+ * route the user into billing.
+ */
+export const SeatMeter: React.FC<SeatMeterProps> = ({ used, limit, planLabel, canUpgrade = true }) => {
+  const isUnlimited = limit >= UNLIMITED_THRESHOLD;
+  const rawPercent = limit > 0 ? (used / limit) * 100 : 0;
+  const clampedPercent = Math.min(100, Math.max(0, rawPercent));
+  const showCta = !isUnlimited && rawPercent > CTA_THRESHOLD && canUpgrade;
+  const isCoral = !isUnlimited && rawPercent > CORAL_THRESHOLD;
+  const isAmber = !isUnlimited && rawPercent > CTA_THRESHOLD && !isCoral;
+
+  const handleUpgrade = () => {
+    window.dispatchEvent(new CustomEvent('pulse:settings-navigate', {
+      detail: { section: 'billing' },
+    }));
+  };
+
+  return (
+    <div className="mt-2 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/40 p-3">
+      <div className="flex items-center justify-between gap-3 mb-1.5">
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="text-sm font-bold text-zinc-900 dark:text-white tabular-nums">
+            {isUnlimited ? (
+              <span className="inline-flex items-center gap-1">
+                <InfinityIcon className="w-3.5 h-3.5" /> {used}
+              </span>
+            ) : (
+              <>{used} <span className="text-zinc-400 dark:text-zinc-500 font-normal">/ {limit}</span></>
+            )}
+          </span>
+          <span
+            className="text-[10px] uppercase tracking-widest font-bold text-zinc-500 dark:text-zinc-400"
+            style={{ fontFamily: "'JetBrains Mono', monospace" }}
+          >
+            {isUnlimited ? 'members' : 'seats'}
+          </span>
+          <span className="text-xs text-zinc-400 dark:text-zinc-500 truncate">
+            {planLabel} plan
+          </span>
+        </div>
+        {showCta && (
+          <button
+            type="button"
+            onClick={handleUpgrade}
+            aria-label="Upgrade plan to add more seats"
+            className={`shrink-0 inline-flex items-center gap-1 text-xs font-semibold px-2.5 py-1 rounded-md transition ${
+              isCoral
+                ? 'bg-rose-600 hover:bg-rose-700 text-white'
+                : 'bg-amber-500 hover:bg-amber-600 text-white'
+            }`}
+          >
+            Upgrade
+            <ArrowUpRight className="w-3 h-3" />
+          </button>
+        )}
+      </div>
+
+      {!isUnlimited && (
+        <div
+          role="progressbar"
+          aria-valuenow={Math.round(clampedPercent)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${used} of ${limit} seats used`}
+          className="h-1.5 w-full rounded-full bg-zinc-200 dark:bg-zinc-800 overflow-hidden"
+        >
+          <div
+            className={`h-full rounded-full transition-all duration-300 ${
+              isCoral ? 'bg-rose-500' : isAmber ? 'bg-amber-500' : 'bg-zinc-400 dark:bg-zinc-500'
+            }`}
+            style={{ width: `${clampedPercent}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Promotes the seat counter from `text-xs text-zinc-400` (revenue lever in the smallest type on the page) to a horizontal meter card with the Coral-As-Signal escalation DESIGN.md prescribes.

Before:
```
Manage members and invitations for Pulse Inc.    1 / 50 members (Free plan)
```

After (under 70% — purely informational):
```
┌──────────────────────────────────────────────┐
│  3  /  50   seats   Free plan                │
│  ▭ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─   │
│  (6% zinc fill)                              │
└──────────────────────────────────────────────┘
```

70-90% — amber fill + Upgrade CTA surfaces:
```
┌──────────────────────────────────────────────┐
│  38 /  50   seats   Free plan      Upgrade ↗ │
│  ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰─ ─ ─ ─ ─ ─ ─ ─ ─ ─       │
│  (76% amber-500 fill)                        │
└──────────────────────────────────────────────┘
```

>90% — rose fill + emphasised CTA (Coral-As-Signal active):
```
┌──────────────────────────────────────────────┐
│  48 /  50   seats   Free plan      Upgrade ↗ │
│  ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰─ ─    │
│  (96% rose-500 fill)                         │
└──────────────────────────────────────────────┘
```

Unlimited plans (team / growth, limit >= 100_000):
```
┌──────────────────────────────────────────────┐
│  ∞ 412   members   Growth plan               │
│  (no bar — would render useless 0.0001%)     │
└──────────────────────────────────────────────┘
```

## Why progressive thresholds

- DESIGN.md says rose accent is reserved for the >90% red-line. Hard rule
- But going from `bg-zinc-400` → `bg-rose-500` at 90% is a jarring jump. Amber at 70-90% provides a warmup signal
- 70% is also when the Upgrade CTA appears — the meter visually escalates *with* the affordance

## Implementation

- New file: [`src/components/settings/team/SeatMeter.tsx`](../blob/fix/team-settings-seat-meter/src/components/settings/team/SeatMeter.tsx) (~95 lines)
- Replaces 4 lines of inline `<span className="ml-2 text-xs text-zinc-400">` in TeamSettings header
- ARIA `progressbar` role with `valuenow`/`valuemin`/`valuemax` for screen readers
- `tabular-nums` on the count + `JetBrains Mono` on the "seats" unit label
- `Upgrade` button fires `pulse:settings-navigate` with `section: 'billing'` — same routing pattern UsageWarningBanner / Summit / useAIErrorHandler already use
- `canUpgrade` prop (defaults true) hides the CTA from non-billing roles — wired as `isOwner || isAdmin` in TeamSettings

## Test plan

- [ ] Workspace on Free with 3 members (6% usage) → meter shows zinc fill, no Upgrade CTA
- [ ] Workspace on Free with 38 members (76% usage) → meter shows amber fill + Upgrade CTA appears
- [ ] Workspace on Free with 48 members (96% usage) → meter shows rose fill + rose Upgrade CTA
- [ ] Workspace on Growth plan → meter shows `∞ N members`, no bar, no CTA
- [ ] Click Upgrade → Settings section switches to Billing (via existing `pulse:settings-navigate` handler)
- [ ] As a Member-role user (not admin/owner), CTA is hidden even at 96%
- [ ] Dark mode: contrast holds, fill colours readable, border subtle
- [ ] Screen reader announces "N of M seats used" via the progressbar role

## Related

- Closes part of #41 (C1)
- Builds on #52, #53, #54, #55
- C3-merge (invite consolidation) next — single Invite card with "Paste many" toggle

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)