### PR TITLE
fix(team-settings): mutation lock prevents workspace_id race in-flight (#41 F1)

### DIFF
--- a/src/components/Sidebar/WorkspaceSwitcher.tsx
+++ b/src/components/Sidebar/WorkspaceSwitcher.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { useWorkspace } from '../../contexts/WorkspaceContext';
+import toast from 'react-hot-toast';
+import { useWorkspace, useWorkspaceMutationLock } from '../../contexts/WorkspaceContext';
 import { useAuth } from '../../hooks/useAuth';
 import { Workspace, workspaceService } from '../../services/workspaceService';
 import { DeleteWorkspaceDialog } from '../settings/DeleteWorkspaceDialog';
@@ -57,6 +58,9 @@ export const WorkspaceSwitcher: React.FC<WorkspaceSwitcherProps> = ({ isCollapse
     softDeleteWorkspace,
     hardDeleteWorkspace,
   } = useWorkspace();
+  // Mutation lock — when held, block workspace switching so an in-flight
+  // Team Settings mutation can't return into a different workspace's context.
+  const { isMutating } = useWorkspaceMutationLock();
 
   const [isOpen, setIsOpen] = useState(false);
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -149,6 +153,10 @@ export const WorkspaceSwitcher: React.FC<WorkspaceSwitcherProps> = ({ isCollapse
   }, [isOpen, showCreateForm, showInviteForm]);
 
   const handleSwitch = (ws: Workspace) => {
+    if (isMutating) {
+      toast('Finish the current change before switching workspaces', { icon: '⏳' });
+      return;
+    }
     switchWorkspace(ws.id);
     setIsOpen(false);
   };

--- a/src/components/settings/TeamSettings.tsx
+++ b/src/components/settings/TeamSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useWorkspaceData, useWorkspaceActions, useWorkspacePermissions } from '../../contexts/WorkspaceContext';
+import { useWorkspaceData, useWorkspaceActions, useWorkspacePermissions, useWorkspaceMutationLock } from '../../contexts/WorkspaceContext';
 import { workspaceService, WorkspaceMember, WorkspaceInvite, WORKSPACE_PLAN_LABELS, WORKSPACE_PLAN_LIMITS } from '../../services/workspaceService';
 import { Mail, Users, UserMinus, ChevronDown, Clock, X, Copy, Check } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -21,6 +21,7 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
   const { currentWorkspace, members } = useWorkspaceData();
   const { refreshMembers } = useWorkspaceActions();
   const { isOwner, isAdmin, canManageMembers } = useWorkspacePermissions();
+  const { acquireMutationLock } = useWorkspaceMutationLock();
   // Groups card is gated behind a flag until #42 phase 5 lands a real read
   // consumer (group_grants → mentions / routing / channel ACL). Dev override:
   // ?ff_workspaceGroups=on (also persists to localStorage for that browser).
@@ -90,15 +91,23 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
   }, [loadInvites]);
 
   const handleRoleChange = async (member: WorkspaceMember, newRole: 'admin' | 'member' | 'viewer') => {
-    if (!workspaceId) return;
+    // F1: capture workspaceId at mutation start so a workspace switch
+    // mid-flight can't redirect the await into a different workspace's
+    // context. acquireMutationLock disables the workspace switcher until
+    // release() fires.
+    const wsId = workspaceId;
+    if (!wsId) return;
+    const release = acquireMutationLock();
     try {
-      await workspaceService.updateMemberRole(workspaceId, member.user_id, newRole);
+      await workspaceService.updateMemberRole(wsId, member.user_id, newRole);
       toast.success(`Updated ${member.name || 'member'} to ${newRole}`);
       await refreshMembers();
     } catch {
       toast.error('Failed to update role');
+    } finally {
+      release();
+      setRoleDropdownOpen(null);
     }
-    setRoleDropdownOpen(null);
   };
 
   // Triggers — open the confirm dialog with the right target. Execution
@@ -129,11 +138,20 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
 
   const handleConfirmPending = async () => {
     if (!pendingConfirm) return;
+    // F1: capture workspaceId + acquire lock for the duration of the
+    // mutation. Both remove and revoke paths are workspace-scoped (the
+    // revoke RLS check qualifies workspace_id even though we delete by
+    // invite.id), so switching workspaces mid-await would still race.
+    const wsId = workspaceId;
+    if (!wsId) {
+      setPendingConfirm(null);
+      return;
+    }
+    const release = acquireMutationLock();
     setIsConfirming(true);
     try {
       if (pendingConfirm.kind === 'remove') {
-        if (!workspaceId) return;
-        await workspaceService.removeMember(workspaceId, pendingConfirm.member.user_id);
+        await workspaceService.removeMember(wsId, pendingConfirm.member.user_id);
         toast.success('Member removed');
         await refreshMembers();
       } else {
@@ -150,6 +168,7 @@ export const TeamSettings: React.FC<TeamSettingsProps> = ({ userId }) => {
       toast.error(pendingConfirm.kind === 'remove' ? 'Failed to remove member' : 'Failed to revoke invite');
     } finally {
       setIsConfirming(false);
+      release();
     }
   };
 

--- a/src/components/settings/team/InviteCard.tsx
+++ b/src/components/settings/team/InviteCard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useRef } from 'react';
 import { Send, Loader2, AlertCircle, Check, Mail, FileText, Upload, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { workspaceService } from '../../../services/workspaceService';
+import { useWorkspaceMutationLock } from '../../../contexts/WorkspaceContext';
 import { SettingsCard } from '../shared/SettingsCard';
 import { MonoLabel } from '../shared/MonoLabel';
 import { RoleHelpPopover } from './RoleHelpPopover';
@@ -83,6 +84,7 @@ export const InviteCard: React.FC<InviteCardProps> = ({
   cardRef,
   emailInputRef,
 }) => {
+  const { acquireMutationLock } = useWorkspaceMutationLock();
   const [mode, setMode] = useState<InviteMode>('single');
 
   // Single mode state
@@ -166,10 +168,16 @@ export const InviteCard: React.FC<InviteCardProps> = ({
 
   const handleSingleInvite = async () => {
     if (!inviteEmail || !workspaceId) return;
+    // F1: snapshot workspaceId + acquire lock so the workspace switcher
+    // disables until this completes. workspaceId came in as a prop so the
+    // closure already captures the value at call time, but read into a
+    // local for clarity.
+    const wsId = workspaceId;
+    const release = acquireMutationLock();
     setIsInviting(true);
     try {
       const { isResend, emailDelivery } = await workspaceService.inviteMember(
-        workspaceId,
+        wsId,
         inviteEmail,
         inviteRole,
         { workspaceName },
@@ -190,11 +198,16 @@ export const InviteCard: React.FC<InviteCardProps> = ({
       toast.error(msg);
     } finally {
       setIsInviting(false);
+      release();
     }
   };
 
   const handleBulkSend = async () => {
     if (dedupedValid.length === 0 || !workspaceId) return;
+    // F1: snapshot workspaceId + hold the lock across the whole batch
+    // loop so the switcher stays disabled until every invite resolves.
+    const wsId = workspaceId;
+    const release = acquireMutationLock();
     setIsSending(true);
     setResults(null);
     let ok = 0;
@@ -203,7 +216,7 @@ export const InviteCard: React.FC<InviteCardProps> = ({
     for (const row of dedupedValid) {
       try {
         const { emailDelivery } = await workspaceService.inviteMember(
-          workspaceId,
+          wsId,
           row.email!,
           row.role!,
           { workspaceName },
@@ -224,6 +237,7 @@ export const InviteCard: React.FC<InviteCardProps> = ({
 
     setResults({ ok, failed });
     setIsSending(false);
+    release();
 
     if (ok > 0) toast.success(`Sent ${ok} invite${ok === 1 ? '' : 's'}`);
     if (failed.length > 0) toast.error(`${failed.length} invite${failed.length === 1 ? '' : 's'} failed — see details below`);

--- a/src/contexts/WorkspaceContext.tsx
+++ b/src/contexts/WorkspaceContext.tsx
@@ -54,6 +54,22 @@ export interface WorkspacePermissionsContextType {
   canManageMembers: boolean;
 }
 
+/**
+ * Cross-cutting mutation lock — held while a workspace-scoped mutation
+ * is in flight (e.g. Team Settings inviting, role change, member remove,
+ * invite revoke). Readers use this to disable affordances that would
+ * change `currentWorkspace` mid-mutation (workspace switcher), avoiding
+ * the race where a fetch returns into a different workspace's context.
+ *
+ * `acquireMutationLock()` returns a release function. Callers should
+ * wrap the await chain in a try/finally so the lock is released even
+ * on error. Counter-based so nested/parallel mutations stack cleanly.
+ */
+export interface WorkspaceMutationLockContextType {
+  isMutating: boolean;
+  acquireMutationLock: () => () => void;
+}
+
 // Aggregated type (backward compat)
 export interface WorkspaceContextType
   extends WorkspaceDataContextType,
@@ -67,6 +83,7 @@ export interface WorkspaceContextType
 export const WorkspaceDataContext = createContext<WorkspaceDataContextType | undefined>(undefined);
 export const WorkspaceActionsContext = createContext<WorkspaceActionsContextType | undefined>(undefined);
 export const WorkspacePermissionsContext = createContext<WorkspacePermissionsContextType | undefined>(undefined);
+export const WorkspaceMutationLockContext = createContext<WorkspaceMutationLockContextType | undefined>(undefined);
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -84,6 +101,21 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [deletedWorkspaces, setDeletedWorkspaces] = useState<Workspace[]>([]);
+
+  // Mutation lock counter (F1). Tracks how many workspace-scoped mutations
+  // are currently in flight so the workspace switcher can disable itself.
+  // Counter (not bool) so nested/parallel mutations stack cleanly.
+  const [mutationLockCount, setMutationLockCount] = useState<number>(0);
+
+  const acquireMutationLock = useCallback((): (() => void) => {
+    setMutationLockCount(n => n + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      setMutationLockCount(n => Math.max(0, n - 1));
+    };
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Data fetching helpers
@@ -421,11 +453,18 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
     canManageMembers,
   }), [isOwner, isAdmin, canManageMembers]);
 
+  const mutationLockValue = useMemo<WorkspaceMutationLockContextType>(() => ({
+    isMutating: mutationLockCount > 0,
+    acquireMutationLock,
+  }), [mutationLockCount, acquireMutationLock]);
+
   return (
     <WorkspaceDataContext.Provider value={dataValue}>
       <WorkspaceActionsContext.Provider value={actionsValue}>
         <WorkspacePermissionsContext.Provider value={permissionsValue}>
-          {children}
+          <WorkspaceMutationLockContext.Provider value={mutationLockValue}>
+            {children}
+          </WorkspaceMutationLockContext.Provider>
         </WorkspacePermissionsContext.Provider>
       </WorkspaceActionsContext.Provider>
     </WorkspaceDataContext.Provider>
@@ -451,6 +490,12 @@ export const useWorkspaceActions = (): WorkspaceActionsContextType => {
 export const useWorkspacePermissions = (): WorkspacePermissionsContextType => {
   const ctx = useContext(WorkspacePermissionsContext);
   if (ctx === undefined) throw new Error('useWorkspacePermissions must be used within a WorkspaceProvider');
+  return ctx;
+};
+
+export const useWorkspaceMutationLock = (): WorkspaceMutationLockContextType => {
+  const ctx = useContext(WorkspaceMutationLockContext);
+  if (ctx === undefined) throw new Error('useWorkspaceMutationLock must be used within a WorkspaceProvider');
   return ctx;
 };
 


### PR DESCRIPTION
## Summary

Closes the workspace-context race where a user starts a Team-Settings mutation (role change, member remove, invite revoke, single/bulk invite send) and then switches workspaces during the in-flight call. Without the guard, the fetch could return into the **new** workspace's context — wrong `refreshMembers()` target, wrong `loadInvites()` fetch, potentially RLS-rejected, at worst a silent data crossover.

Final item on the #41 phase-2 punch list.

## Two-pronged fix

### 1. Snapshot `workspaceId` at mutation start

Every TeamSettings handler now reads `workspaceId` into a local `const wsId` before the first `await`. The await chain uses `wsId`, not the live context binding. Today's code already worked by closure capture, but this makes it **explicit** and survives future edits where someone might pull `workspaceId` from a hook call inside the body.

### 2. Workspace switcher disables while a mutation is in flight

- **New context:** `WorkspaceMutationLockContext` (4th sub-context in `WorkspaceContext`) exposes `{ isMutating, acquireMutationLock }`
- **Counter-based:** `acquireMutationLock()` increments and returns a release function; nested/parallel mutations stack cleanly
- **WorkspaceSwitcher:** reads `isMutating`. `handleSwitch` short-circuits with a toast ("Finish the current change before switching workspaces") when held
- **Producers:** all 4 TeamSettings + 2 InviteCard mutation handlers wrap the await chain in `try { const release = acquireMutationLock(); ... } finally { release(); }`

## Files

| File | Δ | What |
|---|---|---|
| `src/contexts/WorkspaceContext.tsx` | +47 / -1 | New 4th sub-context, hook, counter |
| `src/components/Sidebar/WorkspaceSwitcher.tsx` | +10 / -1 | Read `isMutating`, guard `handleSwitch`, toast |
| `src/components/settings/TeamSettings.tsx` | +25 / -6 | Wrap `handleRoleChange` + `handleConfirmPending`, capture `wsId` |
| `src/components/settings/team/InviteCard.tsx` | +14 / -4 | Wrap `handleSingleInvite` + `handleBulkSend`, capture `wsId` |

## Scope kept tight

- Lock primitive lives in `WorkspaceContext` for cross-section reuse
- **Only Team-Settings mutations** adopt it in this PR. WorkspaceSettings (transfer ownership, soft/hard delete) is a follow-up
- WorkspaceSwitcher's "create child workspace + switch" path is **not** guarded — separate flow, rare, can be follow-up

## Backward compat

- Aggregated `useWorkspace()` hook unchanged — does **not** include the lock fields, to keep the type stable for existing consumers
- Existing 3 sub-context hooks (`useWorkspaceData`, `useWorkspaceActions`, `useWorkspacePermissions`) unchanged
- New `useWorkspaceMutationLock()` hook for the two new producers + one new consumer

## Test plan

- [ ] Open Team Settings. Click a member's role dropdown, change role → toast confirms, no glitches
- [ ] Open the workspace switcher (sidebar) **mid-role-change** (use Chrome DevTools throttling to slow the await chain): click another workspace → see toast "Finish the current change before switching workspaces" + workspace doesn't switch
- [ ] After the role change resolves, switcher works normally again
- [ ] Same flow with Remove member confirm dialog — click "Remove member", then try to switch workspaces while the await is in flight → blocked + toast
- [ ] Same flow with Revoke invite → blocked + toast
- [ ] Single invite: type email, click Send, immediately try to switch → blocked + toast
- [ ] Bulk invite: paste 5 emails, click Send (loop), try to switch mid-loop → blocked + toast for the *entire* loop duration
- [ ] Nested case (theoretical): trigger two mutations near-simultaneously → counter handles it; release each independently, lock clears only after both fire
- [ ] Aggregated `useWorkspace()` consumers unchanged (no compile errors elsewhere)

## What this is NOT

- Not a refactor of `workspaceService` — same calls, same args. Lock is purely client-side
- Not a server-side optimistic-concurrency token — separate concern. The server still trusts `workspaceId` in the request body
- Not a global mutation lock across all features — scope is workspace-scoped mutations only. Profile, billing, etc are unaffected

## Related

- Closes part of #41 (F1) — **final phase-2 punch list item**
- Builds on the full #41 phase-2 series: #52, #53, #54, #55, #56, #57, #58
- Follow-up: extend lock adoption to WorkspaceSettings (transfer / delete) + WorkspaceSwitcher's create-child path

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)