### PR TITLE
feat(permissions): catalog substrate — permissions + workspace_roles + role_permissions tables (#42 Sub-PR 1)

### DIFF
--- a/supabase/migrations/20260521000000_permissions_catalog_substrate.sql
+++ b/supabase/migrations/20260521000000_permissions_catalog_substrate.sql
@@ -1,0 +1,391 @@
+-- 20260521000000_permissions_catalog_substrate.sql
+-- Issue #42 Sub-PR 1 — permissions catalog substrate.
+--
+-- Adds the three foundation tables for the permissions epic. No application
+-- code consumes them yet; that's intentional. RLS still enforces via
+-- workspace_members.role IN ('owner','admin'). Sub-PR 3 introduces the
+-- resolver, Sub-PR 4 migrates RLS policies one resource at a time.
+--
+-- Tables:
+--   permissions       — global taxonomy (23 seed rows mirror RolePermissionsMatrixCard)
+--   workspace_roles   — per-workspace roles (4 system roles seeded for each)
+--   role_permissions  — role → permission grants
+--
+-- A trigger on workspaces seeds the 4 system roles for any future workspace,
+-- so the substrate stays consistent without requiring Sub-PR 2+ to land.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. permissions catalog (global)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.permissions (
+  key         text PRIMARY KEY,
+  category    text NOT NULL,
+  description text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.permissions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS permissions_select_authenticated ON public.permissions;
+CREATE POLICY permissions_select_authenticated
+  ON public.permissions
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- No INSERT/UPDATE/DELETE policies — taxonomy is service-role only.
+
+-- ---------------------------------------------------------------------------
+-- 2. workspace_roles (per-workspace)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.workspace_roles (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  key          text NOT NULL,
+  name         text NOT NULL,
+  is_system    boolean NOT NULL DEFAULT false,
+  rank         int NOT NULL DEFAULT 100,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (workspace_id, key)
+);
+CREATE INDEX IF NOT EXISTS workspace_roles_workspace_idx
+  ON public.workspace_roles(workspace_id);
+
+ALTER TABLE public.workspace_roles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS workspace_roles_select_member ON public.workspace_roles;
+CREATE POLICY workspace_roles_select_member
+  ON public.workspace_roles
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.workspace_members wm
+      WHERE wm.workspace_id = workspace_roles.workspace_id
+        AND wm.user_id      = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS workspace_roles_insert_admin ON public.workspace_roles;
+CREATE POLICY workspace_roles_insert_admin
+  ON public.workspace_roles
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    is_system = false
+    AND EXISTS (
+      SELECT 1 FROM public.workspace_members wm
+      WHERE wm.workspace_id = workspace_roles.workspace_id
+        AND wm.user_id      = auth.uid()
+        AND wm.role         IN ('owner','admin')
+    )
+  );
+
+DROP POLICY IF EXISTS workspace_roles_update_admin ON public.workspace_roles;
+CREATE POLICY workspace_roles_update_admin
+  ON public.workspace_roles
+  FOR UPDATE
+  TO authenticated
+  USING (
+    is_system = false
+    AND EXISTS (
+      SELECT 1 FROM public.workspace_members wm
+      WHERE wm.workspace_id = workspace_roles.workspace_id
+        AND wm.user_id      = auth.uid()
+        AND wm.role         IN ('owner','admin')
+    )
+  )
+  WITH CHECK (
+    is_system = false
+    AND EXISTS (
+      SELECT 1 FROM public.workspace_members wm
+      WHERE wm.workspace_id = workspace_roles.workspace_id
+        AND wm.user_id      = auth.uid()
+        AND wm.role         IN ('owner','admin')
+    )
+  );
+
+DROP POLICY IF EXISTS workspace_roles_delete_admin ON public.workspace_roles;
+CREATE POLICY workspace_roles_delete_admin
+  ON public.workspace_roles
+  FOR DELETE
+  TO authenticated
+  USING (
+    is_system = false
+    AND EXISTS (
+      SELECT 1 FROM public.workspace_members wm
+      WHERE wm.workspace_id = workspace_roles.workspace_id
+        AND wm.user_id      = auth.uid()
+        AND wm.role         IN ('owner','admin')
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. role_permissions junction
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.role_permissions (
+  role_id        uuid NOT NULL REFERENCES public.workspace_roles(id) ON DELETE CASCADE,
+  permission_key text NOT NULL REFERENCES public.permissions(key)    ON DELETE CASCADE,
+  granted_at     timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (role_id, permission_key)
+);
+CREATE INDEX IF NOT EXISTS role_permissions_role_idx
+  ON public.role_permissions(role_id);
+CREATE INDEX IF NOT EXISTS role_permissions_permission_idx
+  ON public.role_permissions(permission_key);
+
+ALTER TABLE public.role_permissions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS role_permissions_select_member ON public.role_permissions;
+CREATE POLICY role_permissions_select_member
+  ON public.role_permissions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+        FROM public.workspace_roles wr
+        JOIN public.workspace_members wm ON wm.workspace_id = wr.workspace_id
+       WHERE wr.id      = role_permissions.role_id
+         AND wm.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS role_permissions_insert_admin ON public.role_permissions;
+CREATE POLICY role_permissions_insert_admin
+  ON public.role_permissions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+        FROM public.workspace_roles wr
+        JOIN public.workspace_members wm ON wm.workspace_id = wr.workspace_id
+       WHERE wr.id        = role_permissions.role_id
+         AND wr.is_system = false
+         AND wm.user_id   = auth.uid()
+         AND wm.role      IN ('owner','admin')
+    )
+  );
+
+DROP POLICY IF EXISTS role_permissions_delete_admin ON public.role_permissions;
+CREATE POLICY role_permissions_delete_admin
+  ON public.role_permissions
+  FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+        FROM public.workspace_roles wr
+        JOIN public.workspace_members wm ON wm.workspace_id = wr.workspace_id
+       WHERE wr.id        = role_permissions.role_id
+         AND wr.is_system = false
+         AND wm.user_id   = auth.uid()
+         AND wm.role      IN ('owner','admin')
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4. Seed the permission taxonomy (mirrors RolePermissionsMatrixCard.tsx:34-72)
+-- ---------------------------------------------------------------------------
+INSERT INTO public.permissions (key, category, description) VALUES
+  -- Use product
+  ('workspace.read',                'Use product',  'Sign in and use the workspace'),
+  ('workspace.use',                 'Use product',  'Send messages, voxes, and use AI'),
+  ('integrations.personal.connect', 'Use product',  'Connect personal integrations (per-user OAuth: Gmail, Calendar, etc.)'),
+  -- Members
+  ('members.read',                  'Members',      'View team roster'),
+  ('members.invite',                'Members',      'Invite new members'),
+  ('members.invite_bulk',           'Members',      'Bulk invite via CSV'),
+  ('members.update_role',           'Members',      'Change member roles (cannot change owner role)'),
+  ('members.remove',                'Members',      'Remove members'),
+  ('groups.manage',                 'Members',      'Create and manage workspace groups'),
+  -- Organization
+  ('workspace.update',              'Organization', 'Edit org profile (name, logo, etc.)'),
+  ('workspace.policy.auto_join',    'Organization', 'Manage membership policy (auto-join by domain)'),
+  ('integrations.workspace.manage', 'Organization', 'Manage workspace-shared integrations'),
+  ('workspace.archive',             'Organization', 'Archive (soft-delete) workspace'),
+  ('workspace.transfer',            'Organization', 'Transfer workspace ownership'),
+  ('workspace.delete',              'Organization', 'Permanently delete workspace (blocked while legal hold is active)'),
+  -- Security
+  ('security.activity.read',        'Security',     'View sign-in activity for all members'),
+  ('security.policy.write',         'Security',     'Configure 2FA / session / IP allowlist'),
+  ('security.2fa.self',             'Security',     'Enroll personal 2FA'),
+  -- Billing
+  ('billing.read',                  'Billing',      'View plan and invoices'),
+  ('billing.write',                 'Billing',      'Change plan or payment method'),
+  -- Compliance
+  ('audit.read',                    'Compliance',   'View audit log'),
+  ('audit.export',                  'Compliance',   'Export audit log (CSV)'),
+  ('compliance.legal_hold',         'Compliance',   'Toggle legal hold')
+ON CONFLICT (key) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 5. Seed 4 system roles + matrix-derived grants for every existing workspace
+-- ---------------------------------------------------------------------------
+DO $seed$
+DECLARE
+  ws record;
+  v_role_id uuid;
+  v_owner_perms  text[] := ARRAY[
+    'workspace.read','workspace.use','integrations.personal.connect',
+    'members.read','members.invite','members.invite_bulk','members.update_role','members.remove','groups.manage',
+    'workspace.update','workspace.policy.auto_join','integrations.workspace.manage',
+    'workspace.archive','workspace.transfer','workspace.delete',
+    'security.activity.read','security.policy.write','security.2fa.self',
+    'billing.read','billing.write',
+    'audit.read','audit.export','compliance.legal_hold'
+  ];
+  v_admin_perms  text[] := ARRAY[
+    'workspace.read','workspace.use','integrations.personal.connect',
+    'members.read','members.invite','members.invite_bulk','members.update_role','members.remove','groups.manage',
+    'workspace.update','workspace.policy.auto_join','integrations.workspace.manage',
+    'workspace.archive',
+    'security.activity.read','security.policy.write','security.2fa.self',
+    'billing.read',
+    'audit.read','audit.export'
+  ];
+  v_member_perms text[] := ARRAY[
+    'workspace.read','workspace.use','integrations.personal.connect',
+    'members.read',
+    'security.2fa.self'
+  ];
+  v_viewer_perms text[] := ARRAY[
+    'workspace.read',
+    'members.read'
+  ];
+  k text;
+BEGIN
+  FOR ws IN SELECT id FROM public.workspaces LOOP
+    -- owner
+    INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+      VALUES (ws.id, 'owner', 'Owner', true, 10)
+      ON CONFLICT (workspace_id, key) DO NOTHING;
+    SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = ws.id AND key = 'owner';
+    FOREACH k IN ARRAY v_owner_perms LOOP
+      INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+    END LOOP;
+
+    -- admin
+    INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+      VALUES (ws.id, 'admin', 'Admin', true, 20)
+      ON CONFLICT (workspace_id, key) DO NOTHING;
+    SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = ws.id AND key = 'admin';
+    FOREACH k IN ARRAY v_admin_perms LOOP
+      INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+    END LOOP;
+
+    -- member
+    INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+      VALUES (ws.id, 'member', 'Member', true, 30)
+      ON CONFLICT (workspace_id, key) DO NOTHING;
+    SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = ws.id AND key = 'member';
+    FOREACH k IN ARRAY v_member_perms LOOP
+      INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+    END LOOP;
+
+    -- viewer
+    INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+      VALUES (ws.id, 'viewer', 'Viewer', true, 40)
+      ON CONFLICT (workspace_id, key) DO NOTHING;
+    SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = ws.id AND key = 'viewer';
+    FOREACH k IN ARRAY v_viewer_perms LOOP
+      INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+    END LOOP;
+  END LOOP;
+END;
+$seed$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Trigger: seed the 4 system roles for any future workspace.
+--    Keeps the substrate consistent regardless of whether Sub-PR 2 has landed.
+--    SECURITY DEFINER so RLS doesn't block the seed.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.seed_system_roles_for_workspace()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_role_id uuid;
+  v_owner_perms  text[] := ARRAY[
+    'workspace.read','workspace.use','integrations.personal.connect',
+    'members.read','members.invite','members.invite_bulk','members.update_role','members.remove','groups.manage',
+    'workspace.update','workspace.policy.auto_join','integrations.workspace.manage',
+    'workspace.archive','workspace.transfer','workspace.delete',
+    'security.activity.read','security.policy.write','security.2fa.self',
+    'billing.read','billing.write',
+    'audit.read','audit.export','compliance.legal_hold'
+  ];
+  v_admin_perms  text[] := ARRAY[
+    'workspace.read','workspace.use','integrations.personal.connect',
+    'members.read','members.invite','members.invite_bulk','members.update_role','members.remove','groups.manage',
+    'workspace.update','workspace.policy.auto_join','integrations.workspace.manage',
+    'workspace.archive',
+    'security.activity.read','security.policy.write','security.2fa.self',
+    'billing.read',
+    'audit.read','audit.export'
+  ];
+  v_member_perms text[] := ARRAY[
+    'workspace.read','workspace.use','integrations.personal.connect',
+    'members.read',
+    'security.2fa.self'
+  ];
+  v_viewer_perms text[] := ARRAY[
+    'workspace.read',
+    'members.read'
+  ];
+  k text;
+BEGIN
+  INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+    VALUES (NEW.id, 'owner', 'Owner', true, 10)
+    ON CONFLICT (workspace_id, key) DO NOTHING;
+  SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = NEW.id AND key = 'owner';
+  FOREACH k IN ARRAY v_owner_perms LOOP
+    INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+    VALUES (NEW.id, 'admin', 'Admin', true, 20)
+    ON CONFLICT (workspace_id, key) DO NOTHING;
+  SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = NEW.id AND key = 'admin';
+  FOREACH k IN ARRAY v_admin_perms LOOP
+    INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+    VALUES (NEW.id, 'member', 'Member', true, 30)
+    ON CONFLICT (workspace_id, key) DO NOTHING;
+  SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = NEW.id AND key = 'member';
+  FOREACH k IN ARRAY v_member_perms LOOP
+    INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  INSERT INTO public.workspace_roles (workspace_id, key, name, is_system, rank)
+    VALUES (NEW.id, 'viewer', 'Viewer', true, 40)
+    ON CONFLICT (workspace_id, key) DO NOTHING;
+  SELECT id INTO v_role_id FROM public.workspace_roles WHERE workspace_id = NEW.id AND key = 'viewer';
+  FOREACH k IN ARRAY v_viewer_perms LOOP
+    INSERT INTO public.role_permissions (role_id, permission_key) VALUES (v_role_id, k) ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS seed_system_roles_after_workspace_insert ON public.workspaces;
+CREATE TRIGGER seed_system_roles_after_workspace_insert
+  AFTER INSERT ON public.workspaces
+  FOR EACH ROW
+  EXECUTE FUNCTION public.seed_system_roles_for_workspace();
+
+-- Function is trigger-only — not meant to be REST-callable. Lock it down so
+-- anon/authenticated can't reach it via /rest/v1/rpc/.
+REVOKE EXECUTE ON FUNCTION public.seed_system_roles_for_workspace() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.seed_system_roles_for_workspace() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.seed_system_roles_for_workspace() FROM authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Sub-PR 1 of the permissions catalog epic (#42). Ships the three foundation tables for the permissions vocabulary — **no application code consumes them yet**. The matrix card, RLS policies, and TS role checks all still use the existing `workspace_members.role` enum. This is pure substrate so the rest of the epic has a stable ground to stand on.

## What lands

### Tables
| Table | Purpose | Rows after migration |
|---|---|---|
| `permissions` | Global permission taxonomy, 23 keys mirroring [`RolePermissionsMatrixCard.tsx:34-72`](../blob/main/src/components/settings/team/RolePermissionsMatrixCard.tsx#L34-L72) | 23 |
| `workspace_roles` | Per-workspace roles; 4 system roles seeded for each existing workspace | 76 (4 × 19) |
| `role_permissions` | Junction grants role → permission | 931 |

### Seed policy per system role
- **owner** — all 23 permissions
- **admin** — 19 (no `workspace.transfer`, `workspace.delete`, `billing.write`, `compliance.legal_hold`)
- **member** — 5 (`workspace.read`, `workspace.use`, `integrations.personal.connect`, `members.read`, `security.2fa.self`)
- **viewer** — 2 (`workspace.read`, `members.read`)

### Future-workspace trigger
`seed_system_roles_for_workspace()` fires `AFTER INSERT ON workspaces` and seeds the same 4 system roles + grants. `SECURITY DEFINER`, `search_path = public`, `EXECUTE` revoked from `anon`/`authenticated`/`PUBLIC` so it's trigger-only (not exposed via `/rest/v1/rpc/`).

### RLS
- `permissions` — authenticated SELECT only; no write policies (taxonomy is service-role / migrations only).
- `workspace_roles` — workspace members SELECT; owner/admin INSERT/UPDATE/DELETE **gated to `is_system = false`** so system roles can't be tampered with by app users.
- `role_permissions` — workspace members SELECT; owner/admin INSERT/DELETE on non-system roles only.

## Verification on cloud (ucaeuszgoihoyrvhewxk)

| Check | Result |
|---|---|
| `permissions` row count | **23** ✅ |
| `workspace_roles` row count | **76** ✅ (4 × 19 workspaces) |
| `workspace_roles` is_system count | **76** ✅ (all system) |
| `role_permissions` row count | **931** ✅ (49 × 19) |
| Workspaces seeded | **19 / 19** ✅ |
| Per-role grants/workspace (owner / admin / member / viewer) | **23 / 19 / 5 / 2** ✅ |
| Trigger on `INSERT INTO workspaces` | seeds **4 roles + 49 grants** then rolled back ✅ |
| Supabase advisor `0028_anon_security_definer_function_executable` | Resolved by `REVOKE EXECUTE … FROM anon, authenticated, PUBLIC` ✅ |

## Out of scope

- `user_has_permission()` resolver — Sub-PR 3
- Matrix card reads from DB — Sub-PR 2
- RLS migrations from `role IN ('owner','admin')` literals to permission checks — Sub-PR 4 (~25 policies, separate sub-issues)
- `group_grants` (group-derived permissions) — Sub-PR 5
- TS hardcoded role check migration — Sub-PR 6
- Dropping `workspace_members.role` enum — Sub-PR 7

## Operational notes

- Migration is **idempotent** — every INSERT uses `ON CONFLICT DO NOTHING`. Safe to replay.
- The 7 unapplied local migrations dated `20260517*` through `20260520*` are pre-existing drift unrelated to this PR.
- Background CI is still red on `main` per `docs/plans/2026-05-15-team-mgmt-audit-continuation.md`; merge with `--admin --merge`.

## Test plan

- [x] Migration applied cleanly to cloud via Supabase MCP
- [x] All 6 verification queries returned expected counts
- [x] Trigger probe (INSERT … workspace → ROLLBACK) shows 4 roles + 49 grants seeded
- [x] Advisor `0028` resolved by REVOKE on trigger function
- [ ] No application surface to test — substrate only

## Related

- Epic: #42
- Plan doc: [`docs/plans/2026-05-15-team-mgmt-audit-continuation.md`](../blob/main/docs/plans/2026-05-15-team-mgmt-audit-continuation.md)
- Memory: [`reference_pulse_supabase`](../../.claude/projects/f--pulse1/memory/reference_pulse_supabase.md)

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)