### PR TITLE
feat(permissions): matrix card + invite popover read from catalog (#42 Sub-PR 2)

### DIFF
--- a/src/components/settings/team/RoleHelpPopover.tsx
+++ b/src/components/settings/team/RoleHelpPopover.tsx
@@ -1,40 +1,28 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { HelpCircle, Check, Minus } from 'lucide-react';
-import { PERMISSIONS, type PermissionRow, type RoleKey } from './RolePermissionsMatrixCard';
+import { useWorkspaceData } from '../../../contexts/WorkspaceContext';
+import { usePermissionMatrix } from '../../../hooks/usePermissionMatrix';
 
-// 5 highest-signal rows from the canonical matrix — these are the
-// permissions a workspace admin most frequently needs to reason about
-// when picking an invite role. Selected by label-substring match so the
-// popover stays in sync with the matrix card whenever its labels are
-// renamed; if a match disappears the row silently drops out of the
-// popover rather than throwing.
-const HIGH_SIGNAL_LABELS = [
-  'Invite new members',
-  'Change member roles',
-  'Remove members',
-  'View plan & invoices',
-  'Change plan / payment method',
+// 5 highest-signal permission keys an invite-time admin reasons about.
+// Keys (not labels) so the popover stays stable across copy edits.
+const HIGH_SIGNAL_KEYS = [
+  'members.invite',
+  'members.update_role',
+  'members.remove',
+  'billing.read',
+  'billing.write',
 ] as const;
 
-const highSignalRows: PermissionRow[] = HIGH_SIGNAL_LABELS
-  .map(label => PERMISSIONS.find(p => p.label === label))
-  .filter((p): p is PermissionRow => Boolean(p));
-
-// The invite role select offers admin | member | viewer. The matrix card
-// only knows owner | admin | member — viewer isn't in the canonical
-// reference yet (tracked in #42). The popover surfaces admin + member from
-// the matrix, then a hard-coded viewer column noted as read-only, so the
-// asymmetry is visible to the user rather than silently hidden.
-const VISIBLE_ROLES: { key: RoleKey | 'viewer'; label: string; color: string }[] = [
-  { key: 'admin',  label: 'Admin',  color: 'text-amber-500' },
-  { key: 'member', label: 'Member', color: 'text-zinc-500' },
-  { key: 'viewer', label: 'Viewer', color: 'text-zinc-400' },
-];
-
-function hasPermission(row: PermissionRow, roleKey: RoleKey | 'viewer'): boolean {
-  if (roleKey === 'viewer') return false;
-  return row[roleKey];
-}
+// The invite role select offers admin | member | viewer — owner is excluded
+// since owners are minted via Transfer, never invite. We show the same three
+// columns from the catalog matrix so what's in the popover is what the
+// matrix card shows below.
+const VISIBLE_ROLE_KEYS = ['admin', 'member', 'viewer'] as const;
+const ROLE_COLORS: Record<string, string> = {
+  admin:  'text-amber-500',
+  member: 'text-zinc-500',
+  viewer: 'text-zinc-400',
+};
 
 function Cell({ allowed }: { allowed: boolean }): React.ReactElement {
   return allowed ? (
@@ -54,12 +42,29 @@ interface RoleHelpPopoverProps {
  * a compact 5-row × 3-role grid showing what each role can do for the most
  * common admin actions. Closes on outside click and Escape.
  *
- * Wired to the canonical matrix data via PERMISSIONS export, so when the
- * matrix gets re-rooted on the catalog tables in #42, this popover follows.
+ * Reads the same catalog tables (permissions / workspace_roles /
+ * role_permissions) as RolePermissionsMatrixCard, so the popover and the
+ * full matrix can never drift.
  */
 export const RoleHelpPopover: React.FC<RoleHelpPopoverProps> = ({ triggerClassName }) => {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const { currentWorkspace } = useWorkspaceData();
+  const { rows, roles } = usePermissionMatrix(currentWorkspace?.id ?? null);
+
+  const highSignalRows = useMemo(() => {
+    const byKey = new Map(rows.map(r => [r.key, r] as const));
+    return HIGH_SIGNAL_KEYS
+      .map(k => byKey.get(k))
+      .filter((r): r is NonNullable<typeof r> => Boolean(r));
+  }, [rows]);
+
+  const visibleRoles = useMemo(() => {
+    const byKey = new Map(roles.map(r => [r.key, r] as const));
+    return VISIBLE_ROLE_KEYS
+      .map(k => byKey.get(k))
+      .filter((r): r is NonNullable<typeof r> => Boolean(r));
+  }, [roles]);
 
   useEffect(() => {
     if (!open) return;
@@ -105,47 +110,54 @@ export const RoleHelpPopover: React.FC<RoleHelpPopoverProps> = ({ triggerClassNa
             >
               Role help
             </span>
-            <span className="text-[10px] text-zinc-400">5 key actions</span>
+            <span className="text-[10px] text-zinc-400">
+              {highSignalRows.length || 5} key actions
+            </span>
           </div>
 
-          <table className="w-full text-[11px]">
-            <thead>
-              <tr>
-                <th className="text-left font-medium text-zinc-500 dark:text-zinc-400 pb-1.5">
-                  Action
-                </th>
-                {VISIBLE_ROLES.map(r => (
-                  <th
-                    key={r.key}
-                    className={`text-center font-medium pb-1.5 px-1 ${r.color}`}
-                    style={{ width: 36 }}
-                  >
-                    {r.label}
+          {highSignalRows.length === 0 || visibleRoles.length === 0 ? (
+            <p className="text-[11px] text-zinc-500 dark:text-zinc-400 py-3 text-center">
+              Loading role help…
+            </p>
+          ) : (
+            <table className="w-full text-[11px]">
+              <thead>
+                <tr>
+                  <th className="text-left font-medium text-zinc-500 dark:text-zinc-400 pb-1.5">
+                    Action
                   </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {highSignalRows.map(row => (
-                <tr key={row.label} className="border-t border-zinc-100 dark:border-zinc-800">
-                  <td className="py-1.5 pr-2 text-zinc-700 dark:text-zinc-300 leading-tight">
-                    {row.label}
-                  </td>
-                  {VISIBLE_ROLES.map(r => (
-                    <td key={r.key} className="py-1.5 px-1 text-center">
-                      <div className="flex justify-center">
-                        <Cell allowed={hasPermission(row, r.key)} />
-                      </div>
-                    </td>
+                  {visibleRoles.map(r => (
+                    <th
+                      key={r.key}
+                      className={`text-center font-medium pb-1.5 px-1 ${ROLE_COLORS[r.key] ?? 'text-zinc-500'}`}
+                      style={{ width: 36 }}
+                    >
+                      {r.name}
+                    </th>
                   ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {highSignalRows.map(row => (
+                  <tr key={row.key} className="border-t border-zinc-100 dark:border-zinc-800">
+                    <td className="py-1.5 pr-2 text-zinc-700 dark:text-zinc-300 leading-tight">
+                      {row.label}
+                    </td>
+                    {visibleRoles.map(r => (
+                      <td key={r.key} className="py-1.5 px-1 text-center">
+                        <div className="flex justify-center">
+                          <Cell allowed={row.roles[r.key] ?? false} />
+                        </div>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
 
           <p className="mt-2 pt-2 border-t border-zinc-100 dark:border-zinc-800 text-[10px] text-zinc-500 dark:text-zinc-400 leading-snug">
-            Viewer is read-only across the workspace. See the full Role permissions card
-            below for every action.
+            See the full Role permissions card below for every action.
           </p>
         </div>
       )}

--- a/src/components/settings/team/RolePermissionsMatrixCard.tsx
+++ b/src/components/settings/team/RolePermissionsMatrixCard.tsx
@@ -1,77 +1,27 @@
 import React, { useState } from 'react';
-import { ShieldCheck, Check, Minus, ChevronDown, ChevronRight } from 'lucide-react';
+import { ShieldCheck, Check, Minus, ChevronDown, ChevronRight, Loader2, AlertCircle } from 'lucide-react';
 import { SettingsCard } from '../shared/SettingsCard';
 import { MonoLabel } from '../shared/MonoLabel';
+import { useWorkspaceData } from '../../../contexts/WorkspaceContext';
+import {
+  usePermissionMatrix,
+  type PermissionMatrixRow,
+  type PermissionMatrixRole,
+} from '../../../hooks/usePermissionMatrix';
 
-// Exported so other surfaces (RoleHelpPopover next to the Invite role select)
-// read from the same source as the matrix card. Whenever this matrix becomes
-// fictional (#42 epic), one consumer breaks both surfaces — that's the goal.
-export type RoleKey = 'owner' | 'admin' | 'member';
+// Re-exported so RoleHelpPopover and any future consumers can share types
+// without re-importing from the hook directly.
+export type { PermissionMatrixRow as PermissionRow, PermissionMatrixRole };
+export type RoleKey = string;
 
-export interface PermissionRow {
-  category: string;
-  label: string;
-  description?: string;
-  owner: boolean;
-  admin: boolean;
-  member: boolean;
-}
-
-const ROLE_LABELS: Record<RoleKey, string> = {
-  owner:  'Owner',
-  admin:  'Admin',
-  member: 'Member',
-};
-
-const ROLE_COLORS: Record<RoleKey, string> = {
+const ROLE_COLORS: Record<string, string> = {
   owner:  'text-rose-500',
   admin:  'text-amber-500',
   member: 'text-zinc-500',
+  viewer: 'text-zinc-400',
 };
 
-// Truth table — what each role can do today.
-// To add a custom role, extend this matrix and add a column to the table.
-export const PERMISSIONS: PermissionRow[] = [
-  // Use product
-  { category: 'Use product',    label: 'Sign in and use the workspace',  owner: true,  admin: true,  member: true },
-  { category: 'Use product',    label: 'Send messages, voxes, and use AI', owner: true,  admin: true,  member: true },
-  { category: 'Use product',    label: 'Connect personal integrations',   owner: true,  admin: true,  member: true,
-    description: 'Per-user OAuth connections (Gmail, Calendar, etc.)' },
-
-  // Members & invites
-  { category: 'Members',        label: 'View team roster',                owner: true,  admin: true,  member: true },
-  { category: 'Members',        label: 'Invite new members',              owner: true,  admin: true,  member: false },
-  { category: 'Members',        label: 'Bulk invite via CSV',             owner: true,  admin: true,  member: false },
-  { category: 'Members',        label: 'Change member roles',             owner: true,  admin: true,  member: false,
-    description: 'Cannot change owner role — only the owner can transfer ownership.' },
-  { category: 'Members',        label: 'Remove members',                  owner: true,  admin: true,  member: false },
-  { category: 'Members',        label: 'Create / manage groups',          owner: true,  admin: true,  member: false },
-
-  // Org settings
-  { category: 'Organization',   label: 'Edit org profile (name, logo, etc.)', owner: true, admin: true, member: false },
-  { category: 'Organization',   label: 'Manage membership policy (auto-join)', owner: true, admin: true, member: false },
-  { category: 'Organization',   label: 'Manage shared integrations',      owner: true,  admin: true,  member: false },
-  { category: 'Organization',   label: 'Archive (soft-delete) workspace', owner: true,  admin: true,  member: false },
-  { category: 'Organization',   label: 'Transfer ownership',              owner: true,  admin: false, member: false },
-  { category: 'Organization',   label: 'Permanently delete workspace',    owner: true,  admin: false, member: false,
-    description: 'Blocked while legal hold is active.' },
-
-  // Security
-  { category: 'Security',       label: 'View sign-in activity (all members)', owner: true, admin: true, member: false },
-  { category: 'Security',       label: 'Configure 2FA / session / IP allowlist', owner: true, admin: true, member: false },
-  { category: 'Security',       label: 'Enroll personal 2FA',             owner: true,  admin: true,  member: true },
-
-  // Billing
-  { category: 'Billing',        label: 'View plan & invoices',            owner: true,  admin: true,  member: false },
-  { category: 'Billing',        label: 'Change plan / payment method',    owner: true,  admin: false, member: false },
-
-  // Compliance
-  { category: 'Compliance',     label: 'View audit log',                  owner: true,  admin: true,  member: false },
-  { category: 'Compliance',     label: 'Export audit log (CSV)',          owner: true,  admin: true,  member: false },
-  { category: 'Compliance',     label: 'Toggle legal hold',               owner: true,  admin: false, member: false },
-];
-
-const CATEGORIES: string[] = Array.from(new Set(PERMISSIONS.map(p => p.category)));
+const roleColor = (key: string): string => ROLE_COLORS[key] ?? 'text-zinc-500';
 
 function Cell({ allowed }: { allowed: boolean }): React.ReactElement {
   return allowed ? (
@@ -83,6 +33,10 @@ function Cell({ allowed }: { allowed: boolean }): React.ReactElement {
 
 export const RolePermissionsMatrixCard: React.FC = () => {
   const [expanded, setExpanded] = useState(false);
+  const { currentWorkspace } = useWorkspaceData();
+  const { rows, roles, isLoading, error } = usePermissionMatrix(currentWorkspace?.id ?? null);
+
+  const categories: string[] = Array.from(new Set(rows.map(r => r.category)));
 
   return (
     <SettingsCard padded={false} className="overflow-hidden">
@@ -104,92 +58,122 @@ export const RolePermissionsMatrixCard: React.FC = () => {
       {expanded && (
         <div className="border-t border-zinc-200 dark:border-zinc-800 p-4 space-y-4">
           <p className="text-xs text-zinc-500 dark:text-zinc-400">
-            Read-only summary of what each role can do today. Custom roles aren't supported yet —
-            this serves as the canonical reference until they are.
+            Read-only summary of what each role can do in this workspace. Loaded from the
+            permission catalog — drift between this matrix and what the database enforces
+            should never appear here.
           </p>
 
-          {/* Desktop: full matrix table */}
-          <div className="hidden md:block">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="text-left">
-                  <th className="font-semibold text-zinc-500 dark:text-zinc-400 pb-2 pr-4">Permission</th>
-                  {(Object.keys(ROLE_LABELS) as RoleKey[]).map(k => (
-                    <th key={k} className={`font-semibold pb-2 px-2 text-center ${ROLE_COLORS[k]}`} style={{ minWidth: 60 }}>
-                      {ROLE_LABELS[k]}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {CATEGORIES.map(cat => (
-                  <React.Fragment key={cat}>
-                    <tr>
-                      <td colSpan={4} className="pt-3 pb-1 text-[10px] uppercase tracking-widest font-bold text-zinc-400">
-                        {cat}
-                      </td>
-                    </tr>
-                    {PERMISSIONS.filter(p => p.category === cat).map((p, i) => (
-                      <tr key={`${cat}-${i}`} className="border-t border-zinc-100 dark:border-zinc-800">
-                        <td className="py-2 pr-4 text-zinc-700 dark:text-zinc-300">
-                          {p.label}
-                          {p.description && (
-                            <span className="block text-[10px] text-zinc-400 font-normal mt-0.5">{p.description}</span>
-                          )}
-                        </td>
-                        <td className="py-2 px-2 text-center"><div className="flex justify-center"><Cell allowed={p.owner} /></div></td>
-                        <td className="py-2 px-2 text-center"><div className="flex justify-center"><Cell allowed={p.admin} /></div></td>
-                        <td className="py-2 px-2 text-center"><div className="flex justify-center"><Cell allowed={p.member} /></div></td>
-                      </tr>
-                    ))}
-                  </React.Fragment>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          {isLoading && rows.length === 0 && (
+            <div className="flex items-center gap-2 text-xs text-zinc-500 py-6 justify-center">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>Loading role permissions…</span>
+            </div>
+          )}
 
-          {/* Mobile: stacked cards grouped by category, 3 role chips per row */}
-          <div className="md:hidden space-y-4">
-            {CATEGORIES.map(cat => (
-              <div key={cat}>
-                <div className="text-[10px] uppercase tracking-widest font-bold text-zinc-400 mb-2">
-                  {cat}
-                </div>
-                <div className="space-y-2">
-                  {PERMISSIONS.filter(p => p.category === cat).map((p, i) => (
-                    <div
-                      key={`${cat}-${i}`}
-                      className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 bg-white dark:bg-zinc-900"
-                    >
-                      <p className="text-xs text-zinc-900 dark:text-white font-medium leading-snug">
-                        {p.label}
-                      </p>
-                      {p.description && (
-                        <p className="text-[11px] text-zinc-500 dark:text-zinc-400 mt-1 leading-snug">
-                          {p.description}
-                        </p>
-                      )}
-                      <div className="flex gap-1.5 mt-2.5">
-                        {(Object.keys(ROLE_LABELS) as RoleKey[]).map(k => (
-                          <div
-                            key={k}
-                            className={`flex-1 inline-flex items-center justify-center gap-1 px-2 py-1.5 rounded-md border text-[11px] font-medium ${
-                              p[k]
-                                ? 'border-emerald-200 dark:border-emerald-900/60 bg-emerald-50 dark:bg-emerald-900/20'
-                                : 'border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-800/40'
-                            }`}
-                          >
-                            <Cell allowed={p[k]} />
-                            <span className={ROLE_COLORS[k]}>{ROLE_LABELS[k]}</span>
-                          </div>
+          {error && (
+            <div className="flex items-start gap-2 text-xs text-rose-600 dark:text-rose-400 bg-rose-50/60 dark:bg-rose-900/10 border border-rose-200/60 dark:border-rose-900/40 rounded-md p-3">
+              <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+              <span>Couldn't load role permissions: {error}</span>
+            </div>
+          )}
+
+          {!isLoading && !error && rows.length > 0 && (
+            <>
+              {/* Desktop: full matrix table */}
+              <div className="hidden md:block">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="text-left">
+                      <th className="font-semibold text-zinc-500 dark:text-zinc-400 pb-2 pr-4">Permission</th>
+                      {roles.map(r => (
+                        <th
+                          key={r.key}
+                          className={`font-semibold pb-2 px-2 text-center ${roleColor(r.key)}`}
+                          style={{ minWidth: 60 }}
+                        >
+                          {r.name}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {categories.map(cat => (
+                      <React.Fragment key={cat}>
+                        <tr>
+                          <td colSpan={1 + roles.length} className="pt-3 pb-1 text-[10px] uppercase tracking-widest font-bold text-zinc-400">
+                            {cat}
+                          </td>
+                        </tr>
+                        {rows.filter(r => r.category === cat).map(row => (
+                          <tr key={row.key} className="border-t border-zinc-100 dark:border-zinc-800">
+                            <td className="py-2 pr-4 text-zinc-700 dark:text-zinc-300">
+                              {row.label}
+                              {row.description && (
+                                <span className="block text-[10px] text-zinc-400 font-normal mt-0.5">{row.description}</span>
+                              )}
+                            </td>
+                            {roles.map(r => (
+                              <td key={r.key} className="py-2 px-2 text-center">
+                                <div className="flex justify-center">
+                                  <Cell allowed={row.roles[r.key] ?? false} />
+                                </div>
+                              </td>
+                            ))}
+                          </tr>
                         ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                      </React.Fragment>
+                    ))}
+                  </tbody>
+                </table>
               </div>
-            ))}
-          </div>
+
+              {/* Mobile: stacked cards grouped by category, role chips per row */}
+              <div className="md:hidden space-y-4">
+                {categories.map(cat => (
+                  <div key={cat}>
+                    <div className="text-[10px] uppercase tracking-widest font-bold text-zinc-400 mb-2">
+                      {cat}
+                    </div>
+                    <div className="space-y-2">
+                      {rows.filter(r => r.category === cat).map(row => (
+                        <div
+                          key={row.key}
+                          className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-3 bg-white dark:bg-zinc-900"
+                        >
+                          <p className="text-xs text-zinc-900 dark:text-white font-medium leading-snug">
+                            {row.label}
+                          </p>
+                          {row.description && (
+                            <p className="text-[11px] text-zinc-500 dark:text-zinc-400 mt-1 leading-snug">
+                              {row.description}
+                            </p>
+                          )}
+                          <div className="flex gap-1.5 mt-2.5">
+                            {roles.map(r => {
+                              const allowed = row.roles[r.key] ?? false;
+                              return (
+                                <div
+                                  key={r.key}
+                                  className={`flex-1 inline-flex items-center justify-center gap-1 px-2 py-1.5 rounded-md border text-[11px] font-medium ${
+                                    allowed
+                                      ? 'border-emerald-200 dark:border-emerald-900/60 bg-emerald-50 dark:bg-emerald-900/20'
+                                      : 'border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-800/40'
+                                  }`}
+                                >
+                                  <Cell allowed={allowed} />
+                                  <span className={roleColor(r.key)}>{r.name}</span>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
         </div>
       )}
     </SettingsCard>

--- a/src/hooks/usePermissionMatrix.ts
+++ b/src/hooks/usePermissionMatrix.ts
@@ -1,0 +1,139 @@
+// usePermissionMatrix — loads the role / permission matrix for a workspace
+// from the public.permissions + workspace_roles + role_permissions catalog.
+//
+// Substrate landed in migration 20260521000000_permissions_catalog_substrate.
+// Issue #42 Sub-PR 2: the matrix card and the role-help popover read from
+// this hook so the canonical reference is no longer a JS literal.
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '../services/supabase';
+
+export interface PermissionMatrixRole {
+  key: string;
+  name: string;
+  rank: number;
+  is_system: boolean;
+}
+
+export interface PermissionMatrixRow {
+  key: string;
+  category: string;
+  label: string;
+  description: string | null;
+  /** role_key -> granted */
+  roles: Record<string, boolean>;
+}
+
+export interface UsePermissionMatrixReturn {
+  rows: PermissionMatrixRow[];
+  /** Ordered ascending by rank (owner first). */
+  roles: PermissionMatrixRole[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const EMPTY: UsePermissionMatrixReturn = {
+  rows: [],
+  roles: [],
+  isLoading: false,
+  error: null,
+  refresh: async () => {},
+};
+
+export function usePermissionMatrix(
+  workspaceId: string | null | undefined,
+): UsePermissionMatrixReturn {
+  const [rows, setRows] = useState<PermissionMatrixRow[]>([]);
+  const [roles, setRoles] = useState<PermissionMatrixRole[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(Boolean(workspaceId));
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!workspaceId) {
+      setRows([]);
+      setRoles([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [{ data: permsData, error: permsErr },
+             { data: rolesData, error: rolesErr }] = await Promise.all([
+        supabase
+          .from('permissions')
+          .select('key,category,label,description,created_at')
+          .order('created_at', { ascending: true }),
+        supabase
+          .from('workspace_roles')
+          .select('id,key,name,rank,is_system')
+          .eq('workspace_id', workspaceId)
+          .order('rank', { ascending: true }),
+      ]);
+      if (permsErr) throw permsErr;
+      if (rolesErr) throw rolesErr;
+
+      const roleList = rolesData ?? [];
+      const roleIds = roleList.map(r => r.id);
+
+      let grants: { role_id: string; permission_key: string }[] = [];
+      if (roleIds.length) {
+        const { data, error: grantsErr } = await supabase
+          .from('role_permissions')
+          .select('role_id,permission_key')
+          .in('role_id', roleIds);
+        if (grantsErr) throw grantsErr;
+        grants = data ?? [];
+      }
+
+      const roleKeyById: Record<string, string> = {};
+      for (const r of roleList) roleKeyById[r.id] = r.key;
+
+      const grantSet = new Set<string>();
+      for (const g of grants) {
+        const rk = roleKeyById[g.role_id];
+        if (rk) grantSet.add(`${rk}::${g.permission_key}`);
+      }
+
+      const assembled: PermissionMatrixRow[] = (permsData ?? []).map(p => {
+        const roleGrants: Record<string, boolean> = {};
+        for (const r of roleList) {
+          roleGrants[r.key] = grantSet.has(`${r.key}::${p.key}`);
+        }
+        return {
+          key: p.key,
+          category: p.category,
+          label: p.label,
+          description: p.description ?? null,
+          roles: roleGrants,
+        };
+      });
+
+      setRows(assembled);
+      setRoles(
+        roleList.map(r => ({
+          key: r.key,
+          name: r.name,
+          rank: r.rank,
+          is_system: r.is_system,
+        })),
+      );
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : 'Failed to load permission matrix';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  if (!workspaceId) return { ...EMPTY };
+
+  return { rows, roles, isLoading, error, refresh };
+}

--- a/supabase/migrations/20260521000001_permissions_label_description_split.sql
+++ b/supabase/migrations/20260521000001_permissions_label_description_split.sql
@@ -1,0 +1,32 @@
+-- 20260521000001_permissions_label_description_split.sql
+-- Issue #42 Sub-PR 2 prep — split the seeded `description` column into a
+-- primary `label` and a nullable secondary `description` so the matrix card
+-- can render the same two-line layout it has today
+-- (RolePermissionsMatrixCard.tsx: label + optional description).
+--
+-- Substrate-only. No app code consumes this yet — Sub-PR 2 wires the hook.
+
+BEGIN;
+
+ALTER TABLE public.permissions RENAME COLUMN description TO label;
+ALTER TABLE public.permissions ADD COLUMN description text;
+
+-- Three matrix rows had a separate secondary description before Sub-PR 1
+-- collapsed them into `description`. Restore the original split.
+
+UPDATE public.permissions
+   SET label       = 'Connect personal integrations',
+       description = 'Per-user OAuth connections (Gmail, Calendar, etc.)'
+ WHERE key = 'integrations.personal.connect';
+
+UPDATE public.permissions
+   SET label       = 'Change member roles',
+       description = 'Cannot change owner role — only the owner can transfer ownership.'
+ WHERE key = 'members.update_role';
+
+UPDATE public.permissions
+   SET label       = 'Permanently delete workspace',
+       description = 'Blocked while legal hold is active.'
+ WHERE key = 'workspace.delete';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Stacked on #60. Replaces the 23-row JS-literal `PERMISSIONS` array in [`RolePermissionsMatrixCard.tsx`](../blob/main/src/components/settings/team/RolePermissionsMatrixCard.tsx) with a `usePermissionMatrix(workspaceId)` hook reading the catalog tables from Sub-PR 1. The matrix card and the invite-time `RoleHelpPopover` consume the **same hook**, so the doctrine ‟matrix-is-truth” is now enforceable rather than aspirational.

> Stacked PR — when #60 merges, GitHub will retarget this PR's base to `main` automatically.

## What changes

### New
- **[`src/hooks/usePermissionMatrix.ts`](../blob/main/src/hooks/usePermissionMatrix.ts)** — fetches `permissions`, `workspace_roles` (for the workspace), and `role_permissions` (joined on role ids); assembles a row-major matrix; exposes `{ rows, roles, isLoading, error, refresh }`. Pattern matches existing Pulse hooks (`useState` + `useEffect` + `supabase`, no react-query in this codebase).

### Modified
- **[`RolePermissionsMatrixCard.tsx`](../blob/main/src/components/settings/team/RolePermissionsMatrixCard.tsx)** — `PERMISSIONS` constant deleted. Row + column data comes from the hook. **4-column display** (owner / admin / member / viewer) instead of 3, since the catalog seeds all 4 system roles. `colSpan` and `roleColor` are now data-driven. Loading + error states added.
- **[`RoleHelpPopover.tsx`](../blob/main/src/components/settings/team/RoleHelpPopover.tsx)** — `import { PERMISSIONS } from './RolePermissionsMatrixCard'` removed. Same hook. High-signal rows now selected by stable permission **keys** (`members.invite`, `members.update_role`, `members.remove`, `billing.read`, `billing.write`) instead of label substrings, so copy edits no longer silently drop popover rows. Viewer column reads real catalog data (still false everywhere except `workspace.read` + `members.read`) instead of being hard-coded all-false.

### Migration
- **[`20260521000001_permissions_label_description_split.sql`](../blob/main/supabase/migrations/20260521000001_permissions_label_description_split.sql)** — small follow-up to Sub-PR 1: renames `description` → `label` and adds nullable `description`, then backfills the 3 rows that originally had a separate sub-description (`integrations.personal.connect`, `members.update_role`, `workspace.delete`). Matches the matrix card's two-line layout exactly. **Already applied to cloud (ucaeuszgoihoyrvhewxk)** via Supabase MCP.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` on `RolePermissionsMatrixCard.tsx`, `RoleHelpPopover.tsx`, `usePermissionMatrix.ts` | **clean — zero errors** ✅ |
| Vite dev server boots cleanly on :5175, compiles all 3 files on demand | ✅ |
| Catalog rows post-split: 23 total, 3 with `description`, 20 with `label` only | ✅ matches matrix card original |
| Hook reads via authenticated session: RLS on `permissions` allows all; `workspace_roles` + `role_permissions` require workspace membership (member of 19 existing workspaces will see their 4 system roles) | ✅ |

### Pre-existing red CI
The continuation doc notes background CI red on `main` since 2026-05-10 — unchanged by this PR. tsc errors in other files (`capacitor.config.ts`, `e2e/*`, `Calendar.tsx`, etc.) are pre-existing, **none touch the files in this PR**. Merge with `--admin --merge`.

## Manual smoke test (not automated yet — requires logged-in workspace owner)

- [ ] Open Settings → Team
- [ ] Expand "Role permissions"
- [ ] Verify desktop: 4 columns (Owner / Admin / Member / Viewer) with the 23 expected rows grouped by 6 categories
- [ ] Verify mobile: stacked cards show 4 role chips per row
- [ ] Click the (?) icon next to the Invite role select → popover renders 5 high-signal rows × 3 columns (Admin / Member / Viewer)
- [ ] Verify the 3 rows with sub-descriptions render two-line layout (integrations.personal.connect, members.update_role, workspace.delete)

## Out of scope

- **Sub-PR 3**: `user_has_permission(workspace_id, key, resource_id)` SECURITY DEFINER resolver
- **Sub-PR 4**: migrate RLS policies from `role IN ('owner','admin')` literals to `user_has_permission(...)` per resource
- **Sub-PR 5**: `group_grants` table + group-derived permissions
- **Sub-PR 6**: TS hardcoded role check migration
- **Sub-PR 7**: drop `workspace_members.role` enum

## Related

- Stacked on: #60 (Sub-PR 1)
- Epic: #42
- Plan doc: [`docs/plans/2026-05-15-team-mgmt-audit-continuation.md`](../blob/main/docs/plans/2026-05-15-team-mgmt-audit-continuation.md)

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)