### PR TITLE
feat(permissions): workspace_groups RLS uses user_has_permission (#42 Sub-PR 4a)

### DIFF
--- a/supabase/migrations/20260521000003_workspace_groups_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000003_workspace_groups_rls_to_user_has_permission.sql
@@ -1,0 +1,94 @@
+-- 20260521000003_workspace_groups_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4a — migrate workspace_groups + workspace_group_members
+-- RLS policies from `role IN ('owner','admin')` literals to
+-- `user_has_permission(workspace_id, 'groups.manage')`.
+--
+-- Resource scope: workspace_groups, workspace_group_members.
+-- 5 policies migrated (INSERT/UPDATE/DELETE on workspace_groups;
+-- INSERT/DELETE on workspace_group_members). 2 SELECT policies stay
+-- untouched — they enforce membership only, no role gating.
+--
+-- Behaviour equivalence: per the catalog seed, owner + admin both have
+-- groups.manage; member + viewer do not. So the migration preserves the
+-- pre-migration RLS truth table 1:1.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- workspace_groups
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS workspace_groups_insert ON public.workspace_groups;
+CREATE POLICY workspace_groups_insert
+  ON public.workspace_groups
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.user_has_permission(workspace_id, 'groups.manage')
+  );
+
+DROP POLICY IF EXISTS workspace_groups_update ON public.workspace_groups;
+CREATE POLICY workspace_groups_update
+  ON public.workspace_groups
+  FOR UPDATE
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'groups.manage')
+  )
+  WITH CHECK (
+    public.user_has_permission(workspace_id, 'groups.manage')
+  );
+
+DROP POLICY IF EXISTS workspace_groups_delete ON public.workspace_groups;
+CREATE POLICY workspace_groups_delete
+  ON public.workspace_groups
+  FOR DELETE
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'groups.manage')
+  );
+
+-- ---------------------------------------------------------------------------
+-- workspace_group_members
+--
+-- The INSERT policy preserves its second clause ‟target user must be a
+-- workspace member" — that's a referential invariant, not a role check, so
+-- it stays as-is. Only the first clause (caller is admin+) becomes
+-- user_has_permission(...).
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS workspace_group_members_insert ON public.workspace_group_members;
+CREATE POLICY workspace_group_members_insert
+  ON public.workspace_group_members
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+        FROM public.workspace_groups g
+       WHERE g.id = workspace_group_members.group_id
+         AND public.user_has_permission(g.workspace_id, 'groups.manage')
+    )
+    AND EXISTS (
+      SELECT 1
+        FROM public.workspace_groups   g
+        JOIN public.workspace_members  wm2
+          ON wm2.workspace_id = g.workspace_id
+         AND wm2.user_id      = workspace_group_members.user_id
+       WHERE g.id = workspace_group_members.group_id
+    )
+  );
+
+DROP POLICY IF EXISTS workspace_group_members_delete ON public.workspace_group_members;
+CREATE POLICY workspace_group_members_delete
+  ON public.workspace_group_members
+  FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+        FROM public.workspace_groups g
+       WHERE g.id = workspace_group_members.group_id
+         AND public.user_has_permission(g.workspace_id, 'groups.manage')
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

**First resource in the Sub-PR 4 RLS migration sequence.** Stacked on #62.

Replaces five `role IN ('owner','admin')` literals in the `workspace_groups` + `workspace_group_members` RLS policies with calls to `user_has_permission(workspace_id, 'groups.manage')`. Behaviour preserved 1:1; the catalog seed gives `groups.manage` to owner+admin and not to member+viewer, matching the pre-migration truth table exactly.

> Stack: #60 ← #61 ← #62 ← **this PR**

## Why this resource first

- 5 cohesive policies, single permission key (`groups.manage`)
- Low blast radius — Groups card is feature-flag-gated per #50
- No FK chains, no triggers that depend on role checks
- Good shake-down for the migration pattern that the next ~20 policies will reuse

## Policies migrated

| Table | Policy | Cmd | Before | After |
|---|---|---|---|---|
| `workspace_groups` | `workspace_groups_insert` | INSERT | `wm.role IN ('owner','admin')` | `user_has_permission(workspace_id, 'groups.manage')` |
| `workspace_groups` | `workspace_groups_update` | UPDATE | same | same (USING + WITH CHECK) |
| `workspace_groups` | `workspace_groups_delete` | DELETE | same | same (USING) |
| `workspace_group_members` | `workspace_group_members_insert` | INSERT | role check + target-is-member | `user_has_permission(...)` + target-is-member (kept) |
| `workspace_group_members` | `workspace_group_members_delete` | DELETE | role check | `user_has_permission(...)` |

`workspace_groups_select` and `workspace_group_members_select` are **unchanged** — they enforce membership only, no role gating.

## Verification — 11-probe truth table

Probes use `set_config('request.jwt.claims', ...)` + `SET LOCAL ROLE authenticated` so RLS actually fires. Synthetic admin + member workspace_members rows created inline + deleted in probe cleanup. Each probe captures `RETURNED_SQLSTATE` from any RLS rejection so `42501` (insufficient_privilege) is visible.

| # | Scenario | Expected | Pass |
|---|---|---|---|
| 1 | owner INSERT workspace_groups | success | ✅ |
| 2 | admin INSERT workspace_groups | success | ✅ |
| 3 | member INSERT workspace_groups | blocked(42501) | ✅ |
| 4 | non-member INSERT workspace_groups | blocked(42501) | ✅ |
| 5 | owner UPDATE workspace_groups | success | ✅ |
| 6 | member UPDATE workspace_groups | blocked-by-using (no rows visible) | ✅ |
| 7 | admin INSERT workspace_group_members | success | ✅ |
| 8 | admin INSERT non-member into group (target invariant) | blocked(42501) | ✅ |
| 9 | member INSERT workspace_group_members | blocked(42501) | ✅ |
| 10 | admin DELETE workspace_group_members | success | ✅ |
| 11 | admin DELETE workspace_groups | success | ✅ |

Post-probe cleanup verified: 0 leftover `PROBE_*` groups, 1 member (owner) in test workspace.

## Pattern this PR establishes

The migration in this PR is the template the remaining ~20 policies follow:

1. `DROP POLICY IF EXISTS <name> ON public.<table>;`
2. `CREATE POLICY <name> ON public.<table> FOR <cmd> TO authenticated USING/WITH CHECK (user_has_permission(<table>.workspace_id, '<key>'));`
3. Keep any *non-role* clauses verbatim (target invariants, scope filters).
4. Probe matrix: owner/admin/member/non-member × INSERT/UPDATE/DELETE.

## Next resources (Sub-PR 4b … 4n)

| Resource | Policies | Key |
|---|---|---|
| `workspace_integrations` | 3 | `integrations.workspace.manage` |
| `workspace_invites` | 5 (post-#44) | `members.invite` |
| `workspace_members` | 6 | `members.update_role` / `members.remove` |
| `places` schema | 3 | `workspace.update` |
| `billing_*` | 2 | `billing.read` / `billing.write` |
| `audit_log_and_transfer` | 1 | `audit.read` |
| `workspace_avatars` (storage) | 1 | `workspace.update` |

## Test plan

- [x] Migration applied cleanly via Supabase MCP
- [x] 11-probe RLS truth table verified
- [x] Probe cleanup verified — workspace integrity intact
- [x] SELECT policies left untouched (membership-only logic)

## Related

- Stacked on: #62 (Sub-PR 3) ← #61 (Sub-PR 2) ← #60 (Sub-PR 1)
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)