### PR TITLE
feat(permissions): workspace_integrations RLS uses user_has_permission (#42 Sub-PR 4b)

### DIFF
--- a/supabase/migrations/20260521000004_workspace_integrations_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000004_workspace_integrations_rls_to_user_has_permission.sql
@@ -1,0 +1,52 @@
+-- 20260521000004_workspace_integrations_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4b — migrate workspace_integrations RLS policies from
+-- `role IN ('owner','admin')` literals to
+-- `user_has_permission(workspace_id, 'integrations.workspace.manage')`.
+--
+-- Resource scope: workspace_integrations only.
+-- 3 policies migrated (INSERT/UPDATE/DELETE). 1 SELECT policy untouched.
+--
+-- Behaviour: owner+admin have integrations.workspace.manage in the catalog
+-- seed; member+viewer do not. Truth table preserved 1:1.
+--
+-- Secondary effect: the pre-migration UPDATE policy had only USING (no
+-- WITH CHECK), letting a privileged caller move a row to a workspace
+-- where they lacked permission. The new policy uses WITH CHECK = USING
+-- to align pre- and post-update permission requirements. This matches
+-- the pattern established in Sub-PR 4a (workspace_groups).
+
+BEGIN;
+
+DROP POLICY IF EXISTS workspace_integrations_insert ON public.workspace_integrations;
+CREATE POLICY workspace_integrations_insert
+  ON public.workspace_integrations
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.user_has_permission(workspace_id, 'integrations.workspace.manage')
+  );
+
+DROP POLICY IF EXISTS workspace_integrations_update ON public.workspace_integrations;
+CREATE POLICY workspace_integrations_update
+  ON public.workspace_integrations
+  FOR UPDATE
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'integrations.workspace.manage')
+  )
+  WITH CHECK (
+    public.user_has_permission(workspace_id, 'integrations.workspace.manage')
+  );
+
+DROP POLICY IF EXISTS workspace_integrations_delete ON public.workspace_integrations;
+CREATE POLICY workspace_integrations_delete
+  ON public.workspace_integrations
+  FOR DELETE
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'integrations.workspace.manage')
+  );
+
+-- SELECT policy unchanged — enforces membership only, no role gate.
+
+COMMIT;


### PR DESCRIPTION
## Summary

**Second resource in the Sub-PR 4 sequence.** Stacked on #63.

Replaces 3 `role IN ('owner','admin')` literals on `workspace_integrations` with calls to `user_has_permission(workspace_id, 'integrations.workspace.manage')`. Behaviour preserved 1:1; the catalog seed gives that permission to owner+admin and not to member+viewer.

> Stack: #60 ← #61 ← #62 ← #63 ← **this PR**

## Policies migrated

| Policy | Cmd | Before | After |
|---|---|---|---|
| `workspace_integrations_insert` | INSERT | `wm.role IN ('owner','admin')` | `user_has_permission(workspace_id, 'integrations.workspace.manage')` |
| `workspace_integrations_update` | UPDATE | same (USING only) | same (USING + WITH CHECK) |
| `workspace_integrations_delete` | DELETE | same | same (USING) |

`workspace_integrations_select` unchanged — membership only.

## Secondary hardening note

The pre-migration UPDATE policy had **only `USING`** (no `WITH CHECK`). That technically lets an admin update `workspace_id` to a workspace they don't have permission on — the USING evaluates the OLD row, not the new one. The new policy uses `WITH CHECK = USING`, closing that gap. Same pattern as Sub-PR 4a (#63). Calling it out explicitly so reviewers see this is a small behaviour delta from the pre-migration state.

## Verification — 9-probe truth table

JWT impersonation + `SET LOCAL ROLE authenticated` so RLS actually fires. CHECK constraint on `integration_key` only allows `slack/gmail/google_calendar/google_drive/microsoft/twilio/zapier`, so probes use one valid key per scenario to avoid UNIQUE conflicts.

| # | Scenario | Expected | Pass |
|---|---|---|---|
| 1 | owner INSERT (gmail) | success | ✅ |
| 2 | admin INSERT (google_calendar) | success | ✅ |
| 3 | member INSERT (google_drive) | blocked(42501) | ✅ |
| 4 | non-member INSERT (microsoft) | blocked(42501) | ✅ |
| 5 | owner UPDATE | success | ✅ |
| 6 | admin UPDATE | success | ✅ |
| 7 | member UPDATE | blocked-by-using | ✅ |
| 8 | admin DELETE | success | ✅ |
| 9 | member DELETE | blocked-by-using | ✅ |

Post-probe cleanup verified: 0 integrations + 1 member (owner) in test workspace.

## Test plan

- [x] Migration applied cleanly via Supabase MCP
- [x] 9-probe RLS truth table verified
- [x] Probe cleanup verified — workspace integrity intact
- [x] SELECT policy left untouched (membership-only)

## Related

- Stacked on: #63 (Sub-PR 4a) ← #62 ← #61 ← #60
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)