### PR TITLE
feat(permissions): workspace_members RLS uses user_has_permission (#42 Sub-PR 4d)

### DIFF
--- a/supabase/migrations/20260521000005_workspace_members_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000005_workspace_members_rls_to_user_has_permission.sql
@@ -1,0 +1,96 @@
+-- 20260521000005_workspace_members_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4d — migrate workspace_members RLS from `wm_is_admin()` /
+-- `wm_is_member()` helpers to `user_has_permission(workspace_id, '<key>')`.
+--
+-- Resource scope: workspace_members only.
+-- 4 policies migrated. Triggers untouched (the #39 last-owner protection
+-- BEFORE UPDATE/DELETE trigger is independent of RLS).
+--
+-- Recursion concern (intentionally addressed)
+--   user_has_permission() is SECURITY DEFINER and runs as `postgres`, which
+--   has BYPASSRLS. When it queries workspace_members internally, RLS is
+--   skipped. So RLS on workspace_members that calls user_has_permission()
+--   does NOT recurse — the function reads the table directly without
+--   re-invoking the RLS policy.
+--
+-- Helpers wm_is_admin / wm_is_member
+--   Kept intact. Still used by workspaces_update RLS — Sub-PR 4e will
+--   migrate that policy, after which the helpers can be retired.
+--
+-- Permission key mapping
+--   SELECT  -> members.read         (granted to all 4 system roles, so 1:1 with wm_is_member)
+--   INSERT  -> members.invite       (admin+ only, matches wm_is_admin) PLUS self-bootstrap clause kept verbatim
+--   UPDATE  -> members.update_role  (admin+ only, matches wm_is_admin) PLUS user_id<>auth.uid() and role-escalation guards kept verbatim
+--   DELETE  -> members.remove       (admin+ only, matches wm_is_admin) PLUS self-leave clause kept verbatim
+
+BEGIN;
+
+-- --- SELECT -----------------------------------------------------------------
+DROP POLICY IF EXISTS workspace_members_select ON public.workspace_members;
+CREATE POLICY workspace_members_select
+  ON public.workspace_members
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'members.read')
+  );
+
+-- --- INSERT -----------------------------------------------------------------
+-- Two paths: admin invites OR user inserts themselves as owner (bootstrap).
+-- The self-bootstrap clause is preserved verbatim — bootstrap_workspace()
+-- is SECURITY DEFINER and bypasses RLS, but direct-INSERT callers
+-- (older clients) may still take this path.
+DROP POLICY IF EXISTS workspace_members_insert ON public.workspace_members;
+CREATE POLICY workspace_members_insert
+  ON public.workspace_members
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.user_has_permission(workspace_id, 'members.invite')
+    OR (
+      user_id = auth.uid()
+      AND role = 'owner'
+      AND EXISTS (
+        SELECT 1 FROM public.workspaces w
+         WHERE w.id = workspace_members.workspace_id
+           AND w.owner_id = auth.uid()
+      )
+    )
+  );
+
+-- --- UPDATE -----------------------------------------------------------------
+-- - user_id <> auth.uid()   : admin can't mutate their own role (transfer-of-
+--                              ownership goes through a dedicated RPC).
+-- - role IN (...)            : role escalation guard from #39. Prevents an
+--                              admin from promoting anyone to 'owner' through
+--                              an UPDATE — only the transfer RPC can do that.
+DROP POLICY IF EXISTS workspace_members_update ON public.workspace_members;
+CREATE POLICY workspace_members_update
+  ON public.workspace_members
+  FOR UPDATE
+  TO authenticated
+  USING (
+    user_id <> auth.uid()
+    AND public.user_has_permission(workspace_id, 'members.update_role')
+  )
+  WITH CHECK (
+    user_id <> auth.uid()
+    AND public.user_has_permission(workspace_id, 'members.update_role')
+    AND role IN ('admin','member','viewer')
+  );
+
+-- --- DELETE -----------------------------------------------------------------
+-- Two paths: self-leave (user removes their own row) OR admin removes
+-- another. The last-owner BEFORE DELETE trigger from #39 still blocks the
+-- self-leave path if the caller is the only remaining owner.
+DROP POLICY IF EXISTS workspace_members_delete ON public.workspace_members;
+CREATE POLICY workspace_members_delete
+  ON public.workspace_members
+  FOR DELETE
+  TO authenticated
+  USING (
+    user_id = auth.uid()
+    OR public.user_has_permission(workspace_id, 'members.remove')
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

**Most complex resource in the Sub-PR 4 sequence.** Stacked on #64. Migrates `workspace_members` RLS from the `wm_is_admin()` / `wm_is_member()` helpers to `user_has_permission(workspace_id, '<key>')`. The #39 hardening (last-owner trigger, role-escalation guard, self-bootstrap clause) is preserved verbatim.

> Stack: #60 ← #61 ← #62 ← #63 ← #64 ← **this PR**

## Why no recursion

Worth saying out loud since it's the obvious worry:

- `user_has_permission()` is `SECURITY DEFINER`, runs as `postgres`, which has `BYPASSRLS`.
- Its internal `SELECT … FROM workspace_members` **skips RLS**.
- So an RLS policy on `workspace_members` that calls `user_has_permission()` reads the table once via the function — RLS isn't re-evaluated inside.

No cycle. Verified empirically by 17 probes hitting all four CRUD verbs without infinite-loop / stack-overflow / timeout.

## Permission key mapping

| Cmd | Before (helper) | After (key) |
|---|---|---|
| SELECT | `wm_is_member(workspace_id, auth.uid())` | `user_has_permission(workspace_id, 'members.read')` |
| INSERT | `wm_is_admin(...)` OR self-bootstrap | `user_has_permission(..., 'members.invite')` OR self-bootstrap (verbatim) |
| UPDATE | `user_id<>self AND wm_is_admin(...)` + escalation guard | `user_id<>self AND user_has_permission(..., 'members.update_role')` + escalation guard (verbatim) |
| DELETE | `user_id=self OR wm_is_admin(...)` | `user_id=self OR user_has_permission(..., 'members.remove')` |

`members.read` is granted to **all 4 system roles** in the catalog seed, so it's a 1:1 equivalent of "is a member" — no SELECT visibility change.

## Hardening preserved verbatim

- **Last-owner trigger** (#39 `workspace_members_protect_last_owner` BEFORE UPDATE/DELETE) — fires independently of RLS. Verified: owner trying to self-leave when sole owner gets `check_violation (23514)` not `42501`.
- **Role-escalation guard** in the UPDATE WITH CHECK — `role IN ('admin','member','viewer')` blocks an admin from promoting anyone to owner. Verified: probe #13 returns `42501`.
- **Self-update block** — `user_id <> auth.uid()` on UPDATE USING — admin can't mutate their own role.
- **Self-leave** — `user_id = auth.uid()` on DELETE USING — any member can remove their own row (unless last-owner trigger blocks).
- **Self-bootstrap clause** on INSERT — kept verbatim; supports legacy direct-INSERT paths since `bootstrap_workspace()` is SECURITY DEFINER and bypasses RLS anyway.

## Helpers `wm_is_admin` / `wm_is_member`

Kept intact. Still used by `workspaces_update` RLS — that'll migrate in Sub-PR 4e. Helpers can be retired in the Sub-PR 6/7 cleanup once all callers move.

## Verification — 17-probe matrix

JWT impersonation + `SET LOCAL ROLE authenticated` for RLS to actually fire.

### SELECT visibility (rows visible to each caller for the test workspace)

| # | Caller | Expected | Pass |
|---|---|---|---|
| 1 | owner | 4 | ✅ |
| 2 | admin | 4 | ✅ |
| 3 | member | 4 | ✅ |
| 4 | viewer | 4 | ✅ |
| 5 | non-member | 0 | ✅ |

### INSERT

| # | Scenario | Expected | Pass |
|---|---|---|---|
| 6 | admin invites new member | success | ✅ |
| 7 | member inserts another user | blocked(42501) | ✅ |
| 8 | non-member inserts | blocked(42501) | ✅ |

### UPDATE

| # | Scenario | Expected | Pass |
|---|---|---|---|
| 9 | owner UPDATE member → admin | success | ✅ |
| 10 | admin UPDATE other member | success | ✅ |
| 11 | member UPDATE other member | blocked-by-using | ✅ |
| 12 | admin UPDATE self | blocked-by-using | ✅ |
| 13 | admin escalate someone to owner | **blocked(42501)** (escalation guard) | ✅ |

### DELETE

| # | Scenario | Expected | Pass |
|---|---|---|---|
| 14 | member self-leaves | success | ✅ |
| 15 | viewer DELETE admin | blocked-by-using | ✅ |
| 16 | admin DELETE viewer | success | ✅ |
| 17 | last-owner self-leave | **blocked(23514)** (last-owner trigger) | ✅ |

Probe inserts 4 synthetic members (admin / member / viewer / extra), exercises all 17 cases, then deletes them. Post-probe workspace integrity verified: 1 member (owner).

## Test plan

- [x] Migration applied cleanly via Supabase MCP
- [x] 17-probe matrix covers SELECT/INSERT/UPDATE/DELETE × every role × escalation guard + last-owner trigger
- [x] Recursion path empirically verified (no stack overflow / timeout)
- [x] Helpers untouched — `workspaces_update` still works (Sub-PR 4e migrates it)
- [x] Post-probe cleanup verified

## Related

- Stacked on: #64 ← #63 ← #62 ← #61 ← #60
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)