### PR TITLE
feat(permissions): workspaces_update RLS uses user_has_permission (#42 Sub-PR 4e)

### DIFF
--- a/supabase/migrations/20260521000006_workspaces_update_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000006_workspaces_update_rls_to_user_has_permission.sql
@@ -1,0 +1,44 @@
+-- 20260521000006_workspaces_update_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4e — migrate workspaces_update RLS from wm_is_admin()
+-- to user_has_permission(id, 'workspace.update').
+--
+-- Resource scope: workspaces (UPDATE policy only).
+-- workspaces_select / workspaces_select_deleted / workspaces_insert /
+-- workspaces_delete are unchanged — they use owner_id or membership
+-- EXISTS clauses, not role checks.
+--
+-- Helper retirement
+--   wm_is_admin / wm_is_member are still referenced by
+--   public.user_has_workspace_access() and possibly app code, so they
+--   stay in place. Final retirement scheduled for a later cleanup PR
+--   once consumers are inventoried.
+--
+-- OR clause preserved
+--   The `owner_id = auth.uid()` OR clause is kept as a defensive fallback
+--   for legacy workspaces where owner_id might not have a matching
+--   workspace_members row (e.g. pre-bootstrap_workspace creations).
+--   In normal operation it's redundant — the owner row will always have
+--   workspace.update — but dropping it could break edge cases.
+--
+-- WITH CHECK added
+--   Original policy had USING only. New policy uses WITH CHECK = USING
+--   so post-update row remains visible to the caller. Matches the
+--   hardening pattern from Sub-PR 4a / 4b / 4d.
+
+BEGIN;
+
+DROP POLICY IF EXISTS workspaces_update ON public.workspaces;
+CREATE POLICY workspaces_update
+  ON public.workspaces
+  FOR UPDATE
+  TO authenticated
+  USING (
+    owner_id = auth.uid()
+    OR public.user_has_permission(id, 'workspace.update')
+  )
+  WITH CHECK (
+    owner_id = auth.uid()
+    OR public.user_has_permission(id, 'workspace.update')
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

Stacked on #65. Migrates `workspaces_update` from `wm_is_admin()` to `user_has_permission(id, 'workspace.update')`. The other 4 `workspaces` policies (insert/select/select_deleted/delete) already use `owner_id` or membership EXISTS clauses, so they don't need migration.

> Stack: #60 ← #61 ← #62 ← #63 ← #64 ← #65 ← **this PR**

## Scope

Only `workspaces_update`. Inspection of the live policies showed:

| Policy | Cmd | Logic | Action |
|---|---|---|---|
| `workspaces_insert` | INSERT | `owner_id = auth.uid()` | unchanged |
| `workspaces_select` | SELECT | `deleted_at IS NULL AND EXISTS workspace_members(...)` | unchanged |
| `workspaces_select_deleted` | SELECT | `deleted_at IS NOT NULL AND owner_id = auth.uid()` | unchanged |
| `workspaces_update` | UPDATE | `owner_id=auth.uid() OR wm_is_admin(id, auth.uid())` | **migrated** |
| `workspaces_delete` | DELETE | `owner_id = auth.uid()` | unchanged |

## Migration shape

```sql
USING (
  owner_id = auth.uid()
  OR public.user_has_permission(id, 'workspace.update')
)
WITH CHECK (same as USING)
```

### `owner_id = auth.uid()` OR clause preserved

Defensive fallback for legacy workspaces where the `owner_id` user may not have a matching `workspace_members` row (pre-`bootstrap_workspace` creations or any edge case where the membership row was deleted). In normal operation the OR is redundant — the owner always has `workspace.update` via the catalog — but keeping it preserves the pre-migration safety net.

### WITH CHECK = USING (hardening)

Original policy had USING only; new policy adds matching WITH CHECK so the row remains visible to the caller after the update. Same pattern as Sub-PR 4a / 4b / 4d.

## Helper retirement deferred

`wm_is_admin` / `wm_is_member` are still called by `public.user_has_workspace_access()` (and possibly app code). Helpers stay in place; final retirement scheduled for a later cleanup PR once consumers are inventoried.

## Verification — 5 probes

JWT impersonation + `SET LOCAL ROLE authenticated`. Probe snapshots the original workspace name pre-probe and restores it after, so the test workspace's name doesn't drift.

| # | Caller | Expected | Pass |
|---|---|---|---|
| 1 | owner | success | ✅ |
| 2 | admin | success | ✅ |
| 3 | member | blocked-by-using | ✅ |
| 4 | viewer | blocked-by-using | ✅ |
| 5 | non-member | blocked-by-using | ✅ |

Post-probe verified: 1 member (owner), original workspace name `"Lauren Brickner (Office.Paesanos)"` restored.

## Test plan

- [x] Migration applied cleanly via Supabase MCP
- [x] 5-probe RLS truth table verified
- [x] Other 4 workspaces policies untouched (don't use role checks)
- [x] Helpers preserved (still called by `user_has_workspace_access`)
- [x] Probe cleanup verified — workspace name + members intact

## Related

- Stacked on: #65 (Sub-PR 4d) ← #64 ← #63 ← #62 ← #61 ← #60
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)