### PR TITLE
feat(permissions): workspace_audit_log RLS uses user_has_permission (#42 Sub-PR 4h)

### DIFF
--- a/supabase/migrations/20260521000007_workspace_audit_log_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000007_workspace_audit_log_rls_to_user_has_permission.sql
@@ -1,0 +1,22 @@
+-- 20260521000007_workspace_audit_log_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4h — migrate workspace_audit_log.admins_read_audit_log
+-- from `role IN ('owner','admin')` to user_has_permission(..., 'audit.read').
+--
+-- Single policy migrated. The INSERT policy (service_role_write_audit_log,
+-- WITH CHECK false) stays — service_role bypasses RLS and is the only
+-- legitimate writer.
+--
+-- Per catalog seed: owner+admin have audit.read; member+viewer do not.
+
+BEGIN;
+
+DROP POLICY IF EXISTS admins_read_audit_log ON public.workspace_audit_log;
+CREATE POLICY admins_read_audit_log
+  ON public.workspace_audit_log
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'audit.read')
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

Stacked on #66. Single-policy migration: `workspace_audit_log.admins_read_audit_log` → `user_has_permission(workspace_id, 'audit.read')`.

> Stack: #60 ← #61 ← #62 ← #63 ← #64 ← #65 ← #66 ← **this PR**

## Scope

- `workspace_audit_log.admins_read_audit_log` (SELECT) → migrated.
- `workspace_audit_log.service_role_write_audit_log` (INSERT, `WITH CHECK false`) → unchanged; service_role bypasses RLS.
- `audit_logs` (separate, user-scoped table with no role check) → unchanged.

## Verification — 5 probes

3 synthetic `PROBE_*` audit rows inserted as postgres (bypasses RLS), then each role queries the count of visible rows.

| # | Caller | Expected | Actual | Pass |
|---|---|---|---|---|
| 1 | owner | 3 | 3 | ✅ |
| 2 | admin | 3 | 3 | ✅ |
| 3 | member | 0 | 0 | ✅ |
| 4 | viewer | 0 | 0 | ✅ |
| 5 | non-member | 0 | 0 | ✅ |

Probe rows + synthetic members cleaned up.

## Related

- Stacked on: #66 ← #65 ← #64 ← #63 ← #62 ← #61 ← #60
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)