### PR TITLE
feat(permissions): workspace_avatars storage RLS uses user_has_permission (#42 Sub-PR 4i)

### DIFF
--- a/supabase/migrations/20260521000008_workspace_avatars_storage_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000008_workspace_avatars_storage_rls_to_user_has_permission.sql
@@ -1,0 +1,40 @@
+-- 20260521000008_workspace_avatars_storage_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4i — migrate storage.objects policy
+-- `workspace_admins_manage_avatars` from role IN ('owner','admin') to
+-- user_has_permission(workspace_id, 'workspace.update').
+--
+-- The workspace_id is extracted from the storage path via
+-- `(storage.foldername(name))[1]::uuid` — file convention is
+-- `<workspace_id>/<filename>`. That extraction is preserved verbatim.
+--
+-- The public read policy (public_read_workspace_avatars, SELECT for the
+-- whole bucket) is untouched — avatars are intentionally publicly readable
+-- so img tags can load without auth.
+--
+-- WITH CHECK added (hardening)
+--   Original policy was FOR ALL with USING only. New policy adds matching
+--   WITH CHECK so INSERT/UPDATE row movement requires the same permission.
+
+BEGIN;
+
+DROP POLICY IF EXISTS workspace_admins_manage_avatars ON storage.objects;
+CREATE POLICY workspace_admins_manage_avatars
+  ON storage.objects
+  FOR ALL
+  TO authenticated
+  USING (
+    bucket_id = 'workspace-avatars'
+    AND public.user_has_permission(
+          ((storage.foldername(name))[1])::uuid,
+          'workspace.update'
+        )
+  )
+  WITH CHECK (
+    bucket_id = 'workspace-avatars'
+    AND public.user_has_permission(
+          ((storage.foldername(name))[1])::uuid,
+          'workspace.update'
+        )
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

Stacked on #67. Migrates the `storage.objects` policy for the `workspace-avatars` bucket. workspace_id is extracted from the storage path via `(storage.foldername(name))[1]::uuid`.

> Stack: #60 ← #61 ← #62 ← #63 ← #64 ← #65 ← #66 ← #67 ← **this PR**

## Scope

- `workspace_admins_manage_avatars` (FOR ALL) → migrated to `user_has_permission(..., 'workspace.update')`
- `public_read_workspace_avatars` (SELECT, bucket-wide) → unchanged (avatars are intentionally public for img tags)

## Storage testing gotcha

`storage.objects` has a `BEFORE DELETE` trigger (`storage.protect_delete`) that blocks raw SQL deletes — must use the Storage API. There's an escape hatch GUC `storage.allow_delete_query = 'true'` that the probe sets so the trigger passes but **RLS still fires**. Worth knowing for anyone adding storage probes in future PRs.

## Verification — 6 probes

| # | Caller | Op | Expected | Pass |
|---|---|---|---|---|
| 1 | owner | INSERT | success | ✅ |
| 2 | admin | DELETE | success | ✅ |
| 3 | member | INSERT | blocked(42501) | ✅ |
| 4 | member | DELETE | blocked-by-using | ✅ |
| 5 | non-member | INSERT | blocked(42501) | ✅ |
| 6 | non-member | SELECT (public read still works) | visible | ✅ |

## Related

- Stacked on: #67 ← #66 ← #65 ← #64 ← #63 ← #62 ← #61 ← #60
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)