### PR TITLE
feat(permissions): billing_drift_log + invoices RLS use user_has_permission (#42 Sub-PR 4g)

### DIFF
--- a/supabase/migrations/20260521000009_billing_select_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000009_billing_select_rls_to_user_has_permission.sql
@@ -1,0 +1,41 @@
+-- 20260521000009_billing_select_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4g — migrate billing-related SELECT policies that gate
+-- on workspace_members.role to user_has_permission(workspace_id, 'billing.read').
+--
+-- Policies migrated
+--   billing_drift_log.billing_drift_log_select   (SELECT, role IN ('owner','admin'))
+--   invoices.invoices_select                      (SELECT, role IN ('owner','admin'))
+--
+-- Policies untouched
+--   billing_drift_log_insert  — WITH CHECK false; service_role only
+--   subscriptions_select      — membership only, no role gate
+--   subscription_items_select — same
+--   plans_select              — public catalog (is_active = true)
+--   user_subscriptions / pulse_channel_subscriptions / push_subscriptions
+--                             — owned by individual user, not workspace
+--
+-- Per catalog seed: owner + admin have billing.read; member + viewer don't.
+-- billing.write is owner-only but no app-side policy enforces it — Stripe
+-- writes via service_role; the matrix card surfaces the distinction.
+
+BEGIN;
+
+DROP POLICY IF EXISTS billing_drift_log_select ON public.billing_drift_log;
+CREATE POLICY billing_drift_log_select
+  ON public.billing_drift_log
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'billing.read')
+  );
+
+DROP POLICY IF EXISTS invoices_select ON public.invoices;
+CREATE POLICY invoices_select
+  ON public.invoices
+  FOR SELECT
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'billing.read')
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

Stacked on #68. Two billing-related SELECT policies migrated to `user_has_permission(workspace_id, 'billing.read')`.

> Stack: #60 ← #61 ← #62 ← #63 ← #64 ← #65 ← #66 ← #67 ← #68 ← **this PR**

## Scope

| Table | Policy | Cmd | Action |
|---|---|---|---|
| `billing_drift_log` | `billing_drift_log_select` | SELECT | **migrated** |
| `billing_drift_log` | `billing_drift_log_insert` | INSERT | unchanged (`WITH CHECK false`; service_role only) |
| `invoices` | `invoices_select` | SELECT | **migrated** |
| `subscriptions` | `subscriptions_select` | SELECT | unchanged (membership only) |
| `subscription_items` | `subscription_items_select` | SELECT | unchanged (chains through subscriptions) |
| `plans` | `plans_select` | SELECT | unchanged (public catalog: `is_active = true`) |
| `user_subscriptions` / `pulse_channel_subscriptions` / `push_subscriptions` | — | — | unchanged (per-user, not workspace-scoped) |

## Note on billing.write

`billing.write` is owner-only in the catalog (Change plan / payment method), but **no app-side RLS policy enforces it**. Stripe webhooks write via `service_role`, bypassing RLS. The matrix card surfaces the distinction for users; no policy needs to mirror it.

## Verification — 9 probes

Synthetic billing_drift_log rows use `source = 'manual'` (the source CHECK constraint allows only `accept_invite/remove_member/auto_join_domain/reconciler_diff/manual/other`) + a per-probe-run marker for clean cleanup.

| # | Table | Caller | Expected | Pass |
|---|---|---|---|---|
| 1-2 | billing_drift_log | owner / admin | 2 visible | ✅ |
| 3-5 | billing_drift_log | member / viewer / non-member | 0 | ✅ |
| 6-7 | invoices | owner / admin | 2 visible | ✅ |
| 8-9 | invoices | member / non-member | 0 | ✅ |

Cleanup verified by marker; synthetic members removed.

## Related

- Stacked on: #68 ← #67 ← #66 ← #65 ← #64 ← #63 ← #62 ← #61 ← #60
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)