### PR TITLE
feat(permissions): workspace_invites RLS uses user_has_permission (#42 Sub-PR 4c — LAST in Sub-PR 4 sequence)

### DIFF
--- a/supabase/migrations/20260521000011_workspace_invites_rls_to_user_has_permission.sql
+++ b/supabase/migrations/20260521000011_workspace_invites_rls_to_user_has_permission.sql
@@ -1,0 +1,64 @@
+-- 20260521000011_workspace_invites_rls_to_user_has_permission.sql
+-- Issue #42 Sub-PR 4c — migrate workspace_invites RLS from role IN
+-- ('owner','admin') to user_has_permission(workspace_id, 'members.invite').
+--
+-- Resource scope: workspace_invites only.
+-- 4 policies migrated. The SELECT policy keeps its `email = auth.email()`
+-- clause verbatim so an invitee (not yet a workspace member) can still
+-- see their own pending invite by email match.
+--
+-- Builds on #44 (workspace_invites_rls_self_reference fix) — the
+-- cross-tenant leak is already closed; this PR just centralises the
+-- role check on the catalog vocabulary.
+--
+-- Per catalog seed: owner + admin have members.invite; member + viewer
+-- don't.
+
+BEGIN;
+
+-- --- SELECT -----------------------------------------------------------------
+-- Two paths: invitee by email match OR admin+ on the workspace.
+DROP POLICY IF EXISTS workspace_invites_select ON public.workspace_invites;
+CREATE POLICY workspace_invites_select
+  ON public.workspace_invites
+  FOR SELECT
+  TO authenticated
+  USING (
+    email = auth.email()
+    OR public.user_has_permission(workspace_id, 'members.invite')
+  );
+
+-- --- INSERT -----------------------------------------------------------------
+DROP POLICY IF EXISTS workspace_invites_insert ON public.workspace_invites;
+CREATE POLICY workspace_invites_insert
+  ON public.workspace_invites
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.user_has_permission(workspace_id, 'members.invite')
+  );
+
+-- --- UPDATE -----------------------------------------------------------------
+DROP POLICY IF EXISTS workspace_invites_update ON public.workspace_invites;
+CREATE POLICY workspace_invites_update
+  ON public.workspace_invites
+  FOR UPDATE
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'members.invite')
+  )
+  WITH CHECK (
+    public.user_has_permission(workspace_id, 'members.invite')
+  );
+
+-- --- DELETE -----------------------------------------------------------------
+DROP POLICY IF EXISTS workspace_invites_delete ON public.workspace_invites;
+CREATE POLICY workspace_invites_delete
+  ON public.workspace_invites
+  FOR DELETE
+  TO authenticated
+  USING (
+    public.user_has_permission(workspace_id, 'members.invite')
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

**Final resource in the Sub-PR 4 sequence.** Stacked on #70. Migrates 4 policies on `workspace_invites` from role checks to `user_has_permission(workspace_id, 'members.invite')`.

> Stack: #60 ← #61 ← #62 ← #63 ← #64 ← #65 ← #66 ← #67 ← #68 ← #69 ← #70 ← **this PR**

## Policies migrated

| Policy | Cmd | Notes |
|---|---|---|
| `workspace_invites_select` | SELECT | `email = auth.email()` clause kept verbatim — invitees still see their own pending invite |
| `workspace_invites_insert` | INSERT | admin+ via permission |
| `workspace_invites_update` | UPDATE | admin+; USING + WITH CHECK |
| `workspace_invites_delete` | DELETE | admin+ |

Builds on #44 (the cross-tenant self-reference RLS fix) — that's already closed; this PR just centralises the role vocabulary.

## Verification — 12 probes

JWT claims include the `email` field so `auth.email()` returns the right value during the invitee-by-email probe.

### SELECT (5 probes)

| # | Caller | Expected visible | Pass |
|---|---|---|---|
| 1 | owner | 1 | ✅ |
| 2 | admin | 1 | ✅ |
| 3 | member (no email match) | 0 | ✅ |
| 4 | **invitee (email match, not yet a workspace member)** | **1** | ✅ |
| 5 | stranger | 0 | ✅ |

### INSERT (3 probes)

| # | Caller | Expected | Pass |
|---|---|---|---|
| 6 | admin | success | ✅ |
| 7 | member | blocked(42501) | ✅ |
| 8 | non-member | blocked(42501) | ✅ |

### UPDATE / DELETE (4 probes)

| # | Caller | Op | Expected | Pass |
|---|---|---|---|---|
| 9 | admin | UPDATE | success | ✅ |
| 10 | member | UPDATE | blocked-by-using | ✅ |
| 11 | member | DELETE | blocked-by-using | ✅ |
| 12 | admin | DELETE | success | ✅ |

## Sub-PR 4 sequence: complete 🎉

| Sub-PR | Resource | Policies | Status |
|---|---|---|---|
| 4a | workspace_groups + workspace_group_members | 5 | ✅ #63 |
| 4b | workspace_integrations | 3 | ✅ #64 |
| 4c | **workspace_invites** | **4** | ✅ **this PR** |
| 4d | workspace_members | 4 | ✅ #65 |
| 4e | workspaces (update only) | 1 | ✅ #66 |
| 4f | places + entity_places | 3 | ✅ #70 |
| 4g | billing_drift_log + invoices | 2 | ✅ #69 |
| 4h | workspace_audit_log | 1 | ✅ #67 |
| 4i | workspace_avatars storage | 1 | ✅ #68 |

**Total: 24 policies migrated across 12 tables**, all behavior-preserving 1:1, with WITH CHECK hardening added on the UPDATE policies that previously had USING only.

## What remains in #42

- **Sub-PR 5** — `group_grants` table + extend resolver to walk groups (the `p_resource_id` parameter finally becomes meaningful)
- **Sub-PR 6** — TS hardcoded role check migration; retire `wm_is_admin` / `wm_is_member` helpers; migrate `user_has_workspace_access()` last consumer
- **Sub-PR 7** — drop `workspace_members.role` text column + CHECK (only after 4 + 6 complete)

## Related

- Stacked on: #70 ← #69 ← #68 ← #67 ← #66 ← #65 ← #64 ← #63 ← #62 ← #61 ← #60
- Epic: #42

---

*Tracked via /git-tracker.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)