### PR TITLE
feat(permissions): retire wm_is_* + uhwa via catalog + hasPermission() (#42 Sub-PR 6)

### DIFF
--- a/src/contexts/WorkspaceContext.tsx
+++ b/src/contexts/WorkspaceContext.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../hooks/useAuth';
 import { workspaceService, Workspace, WorkspaceMember, WorkspacePlan, WorkspaceUpdatableFields } from '../services/workspaceService';
 import { supabase } from '../services/supabase';
 import { emitWorkspaceChanged, emitWorkspaceCleared } from '../services/workspaceEvents';
+import { usePermissionMatrix } from '../hooks/usePermissionMatrix';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -52,6 +53,16 @@ export interface WorkspacePermissionsContextType {
   isOwner: boolean;
   isAdmin: boolean;
   canManageMembers: boolean;
+  /**
+   * Catalog-backed permission check. Returns true when the current user's
+   * role has `key` granted in the workspace's permission catalog. Fail-closed
+   * during catalog load and when the user is not a workspace member.
+   *
+   * Does not yet consult group_grants (#42 Sub-PR 5 substrate exists; UI/read
+   * consumer lands in a follow-up). For workspace-wide role grants — which is
+   * the entire production surface today — this is the authoritative API.
+   */
+  hasPermission: (key: string) => boolean;
 }
 
 /**
@@ -319,6 +330,23 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
   const isAdmin = currentRole === 'owner' || currentRole === 'admin';
   const canManageMembers = isAdmin;
 
+  // Catalog-backed permission check. Loads the permission matrix for the
+  // current workspace once per workspace switch and derives a Set<key> of
+  // permissions granted to the current role.
+  const matrix = usePermissionMatrix(currentWorkspace?.id ?? null);
+  const grantedPermissions = useMemo<Set<string>>(() => {
+    if (!currentRole || matrix.isLoading || matrix.error) return new Set();
+    const set = new Set<string>();
+    for (const row of matrix.rows) {
+      if (row.roles[currentRole]) set.add(row.key);
+    }
+    return set;
+  }, [currentRole, matrix.rows, matrix.isLoading, matrix.error]);
+  const hasPermission = useCallback(
+    (key: string) => grantedPermissions.has(key),
+    [grantedPermissions],
+  );
+
   // ---------------------------------------------------------------------------
   // Actions (stable unless their deps change)
   // ---------------------------------------------------------------------------
@@ -451,7 +479,8 @@ export const WorkspaceProvider: React.FC<WorkspaceProviderProps> = ({ children }
     isOwner,
     isAdmin,
     canManageMembers,
-  }), [isOwner, isAdmin, canManageMembers]);
+    hasPermission,
+  }), [isOwner, isAdmin, canManageMembers, hasPermission]);
 
   const mutationLockValue = useMemo<WorkspaceMutationLockContextType>(() => ({
     isMutating: mutationLockCount > 0,

--- a/supabase/migrations/20260522000001_permissions_retire_wm_helpers.sql
+++ b/supabase/migrations/20260522000001_permissions_retire_wm_helpers.sql
@@ -1,0 +1,49 @@
+-- 20260522000001_permissions_retire_wm_helpers.sql
+-- Issue #42 Sub-PR 6 — retire wm_is_admin / wm_is_member; rewrite
+-- user_has_workspace_access() body to go through the permission catalog.
+--
+-- BEFORE:
+--   user_has_workspace_access(ws_id)
+--     -> wm_is_member(ws_id, auth.uid())
+--     -> EXISTS(SELECT 1 FROM workspace_members WHERE workspace_id=ws_id AND user_id=uid)
+--
+-- AFTER:
+--   user_has_workspace_access(ws_id)
+--     -> user_has_permission(ws_id, 'workspace.read')
+--
+-- workspace.read is granted to all 4 system roles (owner/admin/member/viewer).
+-- For users in the system-role membership shape that's the entire production
+-- userbase today, behavior is unchanged. For future custom roles (is_system =
+-- false) that do NOT grant 'workspace.read', this is a fail-closed semantic
+-- shift — those roles would lose access to the ~70 tables guarded by
+-- user_has_workspace_access(). That's the desired behavior: a custom role
+-- defined without workspace.read should NOT be able to read workspace tables.
+--
+-- Surface inheriting this change without code edits:
+--   - 70 RLS policies across 18 tables
+--   - 3 SECURITY DEFINER functions: get_enriched_workspace_members,
+--     get_workspace_unread_count, write_workspace_audit
+--
+-- Helpers being dropped:
+--   - wm_is_admin(ws_id, uid)  — zero callers in pg_policies or pg_proc
+--   - wm_is_member(ws_id, uid) — only caller is user_has_workspace_access,
+--     which this migration rewrites
+--
+-- Ordering matters: rewrite user_has_workspace_access first, then drop the
+-- helpers it no longer depends on.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.user_has_workspace_access(ws_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'auth', 'pg_catalog'
+AS $function$
+  SELECT public.user_has_permission(ws_id, 'workspace.read')
+$function$;
+
+DROP FUNCTION public.wm_is_member(uuid, uuid);
+DROP FUNCTION public.wm_is_admin(uuid, uuid);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Rewrites `user_has_workspace_access(ws_id)` to delegate to `user_has_permission(ws_id, 'workspace.read')` and drops the orphan `wm_is_admin` / `wm_is_member` helpers. Extends `useWorkspacePermissions` with a catalog-backed `hasPermission(key)` predicate (for future use). Per-row role checks (`member.role === 'owner'` style) are intentionally untouched — they test facts about other people, not current-user permission gates.

Refs #42 Sub-PR 6.

## SQL surface inheriting the change without code edits

- **70 RLS policies** across 18 tables (`crm_*`, `decisions`, `pulse_notes`, `extracted_tasks`, `outcome_blockers`, `quick_vox_messages`, `summit_sessions`, `task_dependencies`, `team_vox_messages`, `voice_thread*`, `vox_*`, `voxer_recordings`, `workspace_outcomes`)
- **3 SECURITY DEFINER functions:** `get_enriched_workspace_members`, `get_workspace_unread_count`, `write_workspace_audit`

All inherit the rewrite automatically because they call `user_has_workspace_access(ws_id)` — only the body of that function changes; no call sites move.

## Helpers retired

| Helper | Reason |
|---|---|
| `wm_is_admin(uuid, uuid)` | Zero callers in `pg_policies` or `pg_proc`. Orphan. |
| `wm_is_member(uuid, uuid)` | Only caller was `user_has_workspace_access`, which this PR rewrites. |

## Semantic note (fail-closed shift)

`workspace.read` is granted to all 4 system roles (owner/admin/member/viewer). For the entire current production userbase, behavior is unchanged. For future custom roles (`is_system = false`) that do NOT include `workspace.read`, this is a fail-closed shift — those roles would lose access to uhwa-protected tables. That is the desired behavior: a custom role defined without `workspace.read` should not be able to read workspace tables.

## TS additions

- `WorkspacePermissionsContextType.hasPermission(key)` — catalog-backed boolean. Loads the permission matrix once per workspace switch via the existing `usePermissionMatrix` hook, derives a `Set<string>` of permission keys for the current role, returns `set.has(key)` in O(1). Fail-closed during catalog load and for non-members.
- Existing `isOwner` / `isAdmin` / `canManageMembers` booleans unchanged (still role-derived). No regression for ~12 existing consumers.

Does NOT yet consult `group_grants` (#42 Sub-PR 5 substrate landed via #72; UI / read consumer will land in a follow-up PR that exercises `p_resource_id`).

## What's intentionally NOT touched

The audit found 8 TS files matching role-check patterns. After triage:

| File | Pattern | Reason untouched |
|---|---|---|
| `SharedCalendarPanel.tsx`, `ContactGroups.tsx`, `ThreadCollaboration.tsx` | role checks | **Non-workspace role** — calendar / contact-group / thread roles are separate concepts |
| `authService.ts` | `role === 'admin'` | **App-level admin** (sb_admin), not workspace |
| `voxModeService.ts`, `WorkspaceSettings.tsx`, `TeamSettings.tsx`, `UserBadge.tsx` | `member.role === 'owner'` | **Per-row checks** asking "is THIS person an owner" — not current-user permission gates |
| `VoiceAgentPanelRedesigned.tsx` | `currentRole === 'user'` | **Chat message role** (user vs assistant), not workspace |

## Probes against cloud

| # | Probe | Result |
|---|---|---|
| P1.1 | `wm_is_admin` exists in `pg_proc` | false ✅ |
| P1.2 | `wm_is_member` exists in `pg_proc` | false ✅ |
| P1.3 | `user_has_workspace_access` exists | true ✅ |
| P1.4 | `user_has_workspace_access` body references `wm_is_member` | false ✅ |
| P1.5 | `user_has_workspace_access` body references `user_has_permission` | true ✅ |
| P2.1 | Workspace owner → `uhwa(own_ws)` | true ✅ |
| P2.2 | Workspace member → `uhwa(own_ws)` | true ✅ |
| P2.3 | Outsider → `uhwa(other_ws)` | false ✅ |
| P2.4 | Outsider → `uhwa(own_ws)` | true ✅ |
| P2.5 | Unauthenticated → `uhwa(any_ws)` | false ✅ |
| P3.1 | Member SELECT count on `decisions` (uhwa-protected) for their workspace | matches total (RLS opens) ✅ |
| P3.2 | Outsider SELECT count on `decisions` for that workspace | 0 (RLS hides) ✅ |

## Test plan

- [ ] Smoke test: load Settings → Team in a non-owner workspace and verify role badges + invite UI render correctly (existing `isAdmin` path unchanged)
- [ ] Add a `console.log` call to `hasPermission('workspace.update')` for the current workspace and verify it returns `true` for owner/admin and `false` for member/viewer
- [ ] Smoke test a uhwa-protected page (e.g. Decisions list) and confirm normal access for workspace members

🤖 Generated with [Claude Code](https://claude.com/claude-code)