### PR TITLE
feat(contacts): P0+P1 polish across Today/People/Circles

### DIFF
--- a/src/components/contacts/CirclesView.tsx
+++ b/src/components/contacts/CirclesView.tsx
@@ -26,7 +26,7 @@ import { CircleBubbleChart } from './CircleBubbleChart';
 import { CircleDetail } from './CircleDetail';
 import { NetworkAnalyticsCard } from './NetworkAnalyticsCard';
 
-import { Loader2, Plus, Wand2 } from 'lucide-react';
+import { Info, Loader2, Plus, Wand2 } from 'lucide-react';
 
 // ==================== TYPES ====================
 
@@ -111,6 +111,14 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
   const [showNewModal, setShowNewModal] = useState(false);
   const [suggestions, setSuggestions] = useState<Omit<ContactCircle, 'id' | 'createdAt' | 'updatedAt'>[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
+  // Session-scoped dismissal of the promoted orphan banner (when >50% of
+  // contacts are uncircled). Persisting to backend is overkill for what is
+  // already an information-dense card — re-shows on next visit.
+  const [orphanBannerDismissed, setOrphanBannerDismissed] = useState(false);
+  // Inline replacement for the previous window.alert() when auto-detect
+  // returns zero suggestions. Drop-in shape mirrors the AI Suggestions
+  // banner so visual rhythm stays consistent.
+  const [noGroupsNotice, setNoGroupsNotice] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const [chartSize, setChartSize] = useState({ width: 600, height: 440 });
 
@@ -158,10 +166,14 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
   const handleAutoDetect = useCallback(async () => {
     if (!userId || detecting) return;
     setDetecting(true);
+    // Clear any prior "no groups" notice — this run is fresh signal.
+    setNoGroupsNotice(false);
     try {
       const detected = await autoDetectCircles(userId, contacts);
       if (detected.length === 0) {
-        alert('No groups detected. Try adding company information to your contacts.');
+        // Informative, not error. Inline banner replaces the previous
+        // window.alert() so it can be dismissed without losing context.
+        setNoGroupsNotice(true);
       } else {
         setSuggestions(detected);
         setShowSuggestions(true);
@@ -239,7 +251,9 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
             </p>
           </div>
           <div className="flex items-center gap-2">
-            {/* Auto-detect */}
+            {/* Group by company — was "Auto-detect" pre-polish. The
+                heuristic is company-name clustering, so naming the action
+                after the input it consumes makes the affordance honest. */}
             <button
               onClick={handleAutoDetect}
               disabled={detecting}
@@ -250,7 +264,7 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
               ) : (
                 <Wand2 className="text-xs" />
               )}
-              {detecting ? 'Detecting…' : 'Auto-detect'}
+              {detecting ? 'Grouping…' : 'Group by company'}
             </button>
             {/* New circle */}
             <button
@@ -291,7 +305,8 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
         )}
       </div>
 
-      {/* AI Suggestions Banner */}
+      {/* AI Suggestions Banner — per-circle [Add] reads as primary action
+          (solid pill); "Accept all" demoted to a quiet outline button. */}
       {showSuggestions && suggestions.length > 0 && (
         <div className="flex-shrink-0 mx-4 mt-3 p-3 bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-xl">
           <div className="flex items-center justify-between mb-2">
@@ -305,7 +320,7 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
               Dismiss
             </button>
           </div>
-          <div className="space-y-1.5 mb-2 max-h-36 overflow-y-auto">
+          <div className="space-y-1.5 mb-3 max-h-36 overflow-y-auto">
             {suggestions.map(s => (
               <div key={s.name} className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2 min-w-0">
@@ -315,7 +330,7 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
                 </div>
                 <button
                   onClick={() => handleAcceptSuggestion(s)}
-                  className="flex-shrink-0 text-xs text-indigo-600 dark:text-indigo-400 font-medium hover:underline"
+                  className="flex-shrink-0 px-2.5 py-1 bg-indigo-600 hover:bg-indigo-700 text-white text-xs font-semibold rounded-md transition-colors"
                 >
                   Add
                 </button>
@@ -324,10 +339,78 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
           </div>
           <button
             onClick={handleAcceptAllSuggestions}
-            className="w-full py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white text-xs font-semibold rounded-lg transition-colors"
+            className="w-full py-1.5 bg-transparent hover:bg-indigo-100 dark:hover:bg-indigo-900/40 border border-indigo-300 dark:border-indigo-700 text-indigo-700 dark:text-indigo-300 text-xs font-medium rounded-lg transition-colors"
           >
-            Accept all {suggestions.length} circles
+            Accept all {suggestions.length}
           </button>
+        </div>
+      )}
+
+      {/* No-groups inline notice — informative, replaces window.alert().
+          Tone: info (neutral surface), not warning/danger. */}
+      {noGroupsNotice && (
+        <div className="flex-shrink-0 mx-4 mt-3 p-3 rounded-xl border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-start gap-2 min-w-0">
+              <Info className="w-4 h-4 mt-0.5 text-zinc-500 dark:text-zinc-400 flex-shrink-0" aria-hidden="true" />
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+                  No groups to suggest yet
+                </p>
+                <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+                  Pulse needs company names on your contacts to group them. Add a company to a few, then try again.
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => setNoGroupsNotice(false)}
+              className="flex-shrink-0 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+              aria-label="Dismiss notice"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Promoted orphan banner — when more than half of contacts aren't in
+          any circle, the flow-card sits between header and bubble chart so
+          it's the first thing the eye lands on. Below 50% the existing
+          bottom-positioned banner inside the chart container still works. */}
+      {!loading
+        && contacts.length > 0
+        && orphans.length / contacts.length > 0.5
+        && !orphanBannerDismissed
+        && (
+        <div className="flex-shrink-0 mx-4 mt-3 p-4 rounded-xl border border-indigo-200 dark:border-indigo-800 bg-white dark:bg-zinc-900 shadow-sm">
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-indigo-100 dark:bg-indigo-900/40 flex items-center justify-center">
+              <Wand2 className="w-4 h-4 text-indigo-600 dark:text-indigo-400" aria-hidden="true" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+                {orphans.length} contact{orphans.length !== 1 ? 's' : ''} {orphans.length === 1 ? "isn't" : "aren't"} in a circle yet
+              </p>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">
+                Pulse looks at shared company names to suggest starter circles. Preview the groupings before anything is saved.
+              </p>
+              <div className="flex items-center gap-2 mt-3">
+                <button
+                  onClick={handleAutoDetect}
+                  disabled={detecting}
+                  className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white text-xs font-semibold rounded-lg transition-colors"
+                >
+                  {detecting ? 'Grouping…' : 'Preview groups'}
+                </button>
+                <button
+                  onClick={() => setOrphanBannerDismissed(true)}
+                  className="px-3 py-1.5 text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 font-medium transition-colors"
+                >
+                  Skip for now
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       )}
 
@@ -364,15 +447,21 @@ export const CirclesView: React.FC<CirclesViewProps> = ({
           />
         )}
 
-        {/* Orphan contacts banner */}
-        {!loading && orphans.length > 0 && (
+        {/* Orphan contacts banner — bottom-of-chart variant. Only renders
+            when ≤50% of contacts are uncircled. Above that threshold, the
+            promoted flow card above the bubble chart takes over. */}
+        {!loading
+          && orphans.length > 0
+          && contacts.length > 0
+          && orphans.length / contacts.length <= 0.5
+          && (
           <div className="absolute bottom-4 left-4 right-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl px-4 py-3 shadow-lg flex items-center justify-between">
             <div>
               <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">
                 {orphans.length} contact{orphans.length !== 1 ? 's' : ''} not in any circle
               </p>
               <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                Use Auto-detect to organise them automatically
+                Use Group by company to organise them automatically
               </p>
             </div>
             <button

--- a/src/components/contacts/Contacts.css
+++ b/src/components/contacts/Contacts.css
@@ -930,6 +930,9 @@
   padding: 24px;
 }
 
+/* Auto-fill columns — 2-up on narrow, 3-up on 1024–1440, 4-up on 1600+.
+   minmax(280px, 1fr) preserves the card composition density while letting
+   the grid breathe on wide monitors. */
 .contacts-grid-inner {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -1145,7 +1148,10 @@
 .contacts-node-lead.C { background: rgba(234, 179, 8, 0.2); color: #eab308; }
 .contacts-node-lead.D { background: rgba(107, 114, 128, 0.2); color: #6b7280; }
 
-/* Quick Actions on Hover */
+/* Quick Actions — always visible (dimmed at rest), full on hover/focus.
+   Drops the previous translateY(8px) entrance so the buttons read as part
+   of the card composition, not a pop-up. WCAG 2.2 ≥24×24 — bumped to 10px
+   padding for a comfortable ≥36px touch target. */
 .contacts-node-actions {
   position: absolute;
   bottom: 16px;
@@ -1153,19 +1159,18 @@
   right: 16px;
   display: flex;
   gap: 8px;
-  opacity: 0;
-  transform: translateY(8px);
-  transition: all 0.3s;
+  opacity: 0.65;
+  transition: opacity 0.2s ease;
 }
 
-.contacts-node:hover .contacts-node-actions {
+.contacts-node:hover .contacts-node-actions,
+.contacts-node:focus-within .contacts-node-actions {
   opacity: 1;
-  transform: translateY(0);
 }
 
 .contacts-node-action {
   flex: 1;
-  padding: 8px;
+  padding: 10px;
   background: var(--cnt-bg-tertiary);
   border: 1px solid var(--cnt-border);
   border-radius: 8px;
@@ -1176,12 +1181,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 36px;
 }
 
-.contacts-node-action:hover {
+.contacts-node-action:hover,
+.contacts-node-action:focus-visible {
   background: var(--cnt-bg-elevated);
   color: var(--cnt-text-primary);
   border-color: var(--cnt-accent-primary);
+  outline: none;
+}
+
+.contacts-node-action:focus-visible {
+  box-shadow: 0 0 0 2px var(--cnt-accent-primary);
 }
 
 /* ============================================

--- a/src/components/contacts/ContactsRedesigned.tsx
+++ b/src/components/contacts/ContactsRedesigned.tsx
@@ -9,6 +9,7 @@ import { DuplicateDetectionModal } from './DuplicateDetectionModal';
 import { SmartListType, RelationshipProfile, LeadScore, getRelationshipHealthColor } from '../../types/relationshipTypes';
 import { ContactDetail } from './ContactDetail';
 import { supabase } from '../../services/supabase';
+import { getContactInitial } from '../../utils/contactInitial';
 import './Contacts.css';
 
 import { ArrowDown, ArrowUp, Bell, Building2, Check, ChevronRight, Clock, Copy, Flame, LayoutGrid, List, MessageSquare, Moon, Network, Plus, Radio, RefreshCw, Search, Snowflake, Star, UserX, Users, Video, Wand2, X, Zap } from 'lucide-react';
@@ -165,22 +166,30 @@ const Sidebar: React.FC<SidebarProps> = ({
       })}
     </div>
 
-    {/* Alerts Banner */}
+    {/* Alerts Banner — migrated from legacy orange RGBs to canonical
+        --pulse-tone-warning tokens. Background and border honor light/dark
+        via the same token, and the foreground rides off --pulse-tone-warning. */}
     {alertCount > 0 && (
       <div className="contacts-sidebar-section" style={{ paddingTop: 0 }}>
         <button
           onClick={onViewAlerts}
           className="contacts-filter-btn active"
           style={{
-            background: 'linear-gradient(135deg, rgba(249, 115, 22, 0.1), rgba(234, 179, 8, 0.1))',
-            border: '1px solid rgba(249, 115, 22, 0.2)',
+            background: 'var(--pulse-tone-warning-soft)',
+            border: '1px solid var(--pulse-tone-warning-soft)',
           }}
         >
           <div className="contacts-filter-btn-content">
-            <div className="contacts-filter-btn-icon" style={{ background: 'rgba(249, 115, 22, 0.2)' }}>
+            <div
+              className="contacts-filter-btn-icon"
+              style={{ background: 'var(--pulse-tone-warning-soft)', color: 'var(--pulse-tone-warning)' }}
+            >
               <Bell />
             </div>
-            <span className="contacts-filter-btn-label" style={{ color: '#f97316' }}>
+            <span
+              className="contacts-filter-btn-label"
+              style={{ color: 'var(--pulse-tone-warning)' }}
+            >
               {alertCount} Alert{alertCount !== 1 ? 's' : ''}
             </span>
           </div>
@@ -261,6 +270,7 @@ const NodeCard: React.FC<NodeCardProps> = ({
         <div className="contacts-node-orbit outer" />
         <div
           className="contacts-node-avatar-inner"
+          aria-hidden="true"
           style={{
             backgroundColor: contact.avatarColor || '#6366f1',
             boxShadow: profile
@@ -268,7 +278,7 @@ const NodeCard: React.FC<NodeCardProps> = ({
               : undefined,
           }}
         >
-          {contact.name.charAt(0)}
+          {getContactInitial(contact.name)}
         </div>
         <div className={`contacts-node-status ${contact.status || 'offline'}`} />
         {profile?.isVip && (
@@ -320,16 +330,48 @@ const NodeCard: React.FC<NodeCardProps> = ({
         </div>
       )}
 
-      {/* Quick Actions */}
-      <div className="contacts-node-actions" onClick={(e) => e.stopPropagation()}>
-        <button className="contacts-node-action" onClick={() => onAction('message')}>
-          <MessageSquare />
+      {/* Quick Actions — always visible (dimmed at rest, full on hover/focus)
+          for discoverability + keyboard a11y. Labels are sr-only spans
+          referenced via aria-labelledby so browser translation tools can
+          translate them (aria-label is not translated). */}
+      <div
+        className="contacts-node-actions"
+        role="group"
+        aria-label="Quick actions"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          className="contacts-node-action"
+          aria-labelledby={`contact-action-msg-${contact.id}`}
+          onClick={() => onAction('message')}
+        >
+          <span id={`contact-action-msg-${contact.id}`} className="sr-only">
+            Message {contact.name}
+          </span>
+          <MessageSquare aria-hidden="true" />
         </button>
-        <button className="contacts-node-action" onClick={() => onAction('vox')}>
-          <Radio />
+        <button
+          type="button"
+          className="contacts-node-action"
+          aria-labelledby={`contact-action-vox-${contact.id}`}
+          onClick={() => onAction('vox')}
+        >
+          <span id={`contact-action-vox-${contact.id}`} className="sr-only">
+            Relay {contact.name}
+          </span>
+          <Radio aria-hidden="true" />
         </button>
-        <button className="contacts-node-action" onClick={() => onAction('meet')}>
-          <Video />
+        <button
+          type="button"
+          className="contacts-node-action"
+          aria-labelledby={`contact-action-meet-${contact.id}`}
+          onClick={() => onAction('meet')}
+        >
+          <span id={`contact-action-meet-${contact.id}`} className="sr-only">
+            Meet with {contact.name}
+          </span>
+          <Video aria-hidden="true" />
         </button>
       </div>
     </div>
@@ -376,6 +418,7 @@ const ListRow: React.FC<ListRowProps> = ({
       <div className="contacts-list-user">
         <div
           className="contacts-list-avatar"
+          aria-hidden="true"
           style={{
             backgroundColor: contact.avatarColor || '#6366f1',
             boxShadow: profile
@@ -383,7 +426,7 @@ const ListRow: React.FC<ListRowProps> = ({
               : undefined,
           }}
         >
-          {contact.name.charAt(0)}
+          {getContactInitial(contact.name)}
           <div
             className="contacts-list-avatar-status"
             style={{

--- a/src/components/contacts/TodayEmptyState.tsx
+++ b/src/components/contacts/TodayEmptyState.tsx
@@ -1,27 +1,37 @@
 // ============================================
 // TODAY EMPTY STATE
-// Celebratory empty state shown when the Today feed has no items.
+// Celebratory + educational empty state: teaches feed vocabulary by showing
+// an inert preview of the six item types that will appear here over time.
 // ============================================
 
 import React, { useState, useEffect } from 'react';
-import { AnimatedIcon } from '../ui/AnimatedIcon';
 
-import { Check, RotateCw } from 'lucide-react';
+import { Bell, Check, Clock, Flame, Mail, RotateCw, Star, Wifi } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface TodayEmptyStateProps {
   onRefresh?: () => void;
 }
 
-const TIPS = [
-  'Staying in touch consistently is the #1 driver of strong relationships. Even a quick message goes a long way.',
-  'Tip: Set a "Keep in Touch" goal on your most important contacts to get proactive reminders.',
-  'Strong relationships are built in small moments. A birthday message or quick check-in matters more than you think.',
-  'Tip: The best time to reach out is before someone goes cold — not after.',
-  'Your network is your net worth. Today is a great day to say hi to someone you haven\'t spoken to in a while.',
+// Type-preview rows — the inert "what shows up here" teaching card.
+// Icons map 1:1 to the FILTER_CHIPS used in the live feed so users build
+// recognition without surface duplication.
+interface PreviewRow {
+  Icon: LucideIcon;
+  label: string;
+  description: string;
+}
+
+const PREVIEW_ROWS: PreviewRow[] = [
+  { Icon: Bell,  label: 'Follow-ups',   description: 'Conversations waiting on your reply' },
+  { Icon: Flame, label: 'Hot leads',    description: 'Warming contacts ready to advance' },
+  { Icon: Star,  label: 'Birthdays',    description: 'Quick personal touches to send' },
+  { Icon: Wifi,  label: 'Cooling',      description: 'Relationships losing momentum' },
+  { Icon: Mail,  label: 'Awaiting',     description: 'Messages you sent that never got an answer' },
+  { Icon: Clock, label: 'Time-sensitive', description: 'Items with a deadline today' },
 ];
 
 export const TodayEmptyState: React.FC<TodayEmptyStateProps> = ({ onRefresh }) => {
-  const [tip] = useState(() => TIPS[Math.floor(Math.random() * TIPS.length)]);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -32,44 +42,70 @@ export const TodayEmptyState: React.FC<TodayEmptyStateProps> = ({ onRefresh }) =
 
   return (
     <div
-      className={`flex flex-col items-center justify-center h-full py-16 px-6 text-center transition-opacity duration-500 ${visible ? 'opacity-100' : 'opacity-0'}`}
+      className={`flex flex-col items-center justify-center h-full py-12 px-6 text-center transition-opacity duration-500 ${visible ? 'opacity-100' : 'opacity-0'}`}
     >
-      {/* Animated checkmark */}
-      <div className="relative mb-6">
-        <div className="w-20 h-20 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
-          <Check className="text-3xl text-emerald-500 dark:text-emerald-400" />
+      {/* Animated checkmark. Ping ring is decorative — guarded by
+          prefers-reduced-motion so the static check still anchors the
+          empty state for users who opt out of motion. Dark-mode opacity
+          dropped from 30% to 20% per Palette plan. */}
+      <div className="relative mb-5">
+        <div className="w-16 h-16 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+          <Check className="w-7 h-7 text-emerald-500 dark:text-emerald-400" />
         </div>
-        {/* Subtle pulse ring */}
-        <div className="absolute inset-0 rounded-full border-2 border-emerald-300 dark:border-emerald-600 animate-ping opacity-30" />
+        <div
+          className="absolute inset-0 rounded-full border-2 border-emerald-300 dark:border-emerald-600 opacity-30 dark:opacity-20 motion-safe:animate-ping motion-reduce:hidden"
+          aria-hidden="true"
+        />
       </div>
 
       {/* Headline */}
-      <h2 className="text-2xl font-bold text-zinc-800 dark:text-zinc-100 mb-2">
+      <h2 className="text-xl font-bold text-zinc-800 dark:text-zinc-100 mb-2">
         All caught up!
       </h2>
 
       {/* Subtext */}
-      <p className="text-zinc-500 dark:text-zinc-400 text-sm max-w-sm mb-8 leading-relaxed">
-        No relationship actions needed right now. We'll surface new items as they come up — check back later or pull to refresh.
+      <p className="text-zinc-500 dark:text-zinc-400 text-sm max-w-sm mb-6 leading-relaxed">
+        No relationship actions need attention right now. Pulse will surface new items here as your network warms up or cools down.
       </p>
 
-      {/* Tip of the day */}
-      <div className="bg-zinc-50 dark:bg-zinc-800/60 border border-zinc-200 dark:border-zinc-700 rounded-xl p-4 max-w-sm mb-6">
-        <div className="flex items-start gap-3">
-          <AnimatedIcon icon="lightbulb" size={18} />
-          <p className="text-xs text-zinc-600 dark:text-zinc-400 leading-relaxed text-left">
-            {tip}
-          </p>
-        </div>
+      {/* Type-preview card — replaces the rotating tip. Dimmed so it reads
+          as informational rather than an active feed. */}
+      <div className="w-full max-w-sm mb-6 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white/60 dark:bg-zinc-900/40 p-3 opacity-75">
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500 mb-2 text-left px-1">
+          What shows up here
+        </p>
+        <ul className="space-y-1.5">
+          {PREVIEW_ROWS.map(({ Icon, label, description }) => (
+            <li
+              key={label}
+              className="flex items-center gap-2.5 px-2 py-1.5 rounded-lg text-left"
+            >
+              <span
+                className="flex-shrink-0 w-6 h-6 rounded-md bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center text-zinc-400 dark:text-zinc-500"
+                aria-hidden="true"
+              >
+                <Icon className="w-3.5 h-3.5" />
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block text-xs font-medium text-zinc-700 dark:text-zinc-300">
+                  {label}
+                </span>
+                <span className="block text-[11px] text-zinc-500 dark:text-zinc-500 truncate">
+                  {description}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
       </div>
 
-      {/* Refresh button */}
+      {/* Refresh CTA */}
       {onRefresh && (
         <button
           onClick={onRefresh}
           className="flex items-center gap-2 text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 font-medium transition-colors"
         >
-          <RotateCw className="text-xs" />
+          <RotateCw className="w-3.5 h-3.5" />
           Check for new items
         </button>
       )}

--- a/src/components/contacts/TodayView.tsx
+++ b/src/components/contacts/TodayView.tsx
@@ -232,15 +232,11 @@ export const TodayView: React.FC<TodayViewProps> = ({ onAction, contacts = [] })
   return (
     <div className="flex flex-col h-full overflow-hidden">
 
-      {/* Header */}
-      <div className="flex-shrink-0 px-4 pt-4 pb-3 border-b border-zinc-200 dark:border-zinc-800">
-        <div className="flex items-center justify-between mb-1">
-          <div>
-            <h2 className="text-lg font-bold text-zinc-800 dark:text-zinc-100">Your Day</h2>
-            <p className="text-xs text-zinc-500 dark:text-zinc-400">
-              Relationships that need your attention
-            </p>
-          </div>
+      {/* Header — H2 dropped (redundant with the active "Today" tab); the
+          previous "Relationships that need your attention" sublabel now
+          rides beneath the summary-stats row as a slim caption (~32px saved). */}
+      <div className="flex-shrink-0 px-4 pt-3 pb-3 border-b border-zinc-200 dark:border-zinc-800">
+        <div className="flex items-center justify-end mb-1">
           <div className="flex items-center gap-1.5">
             {/* Time / Route view mode toggle. Persisted to localStorage so
                 returning users land back in their preferred view. */}
@@ -285,28 +281,33 @@ export const TodayView: React.FC<TodayViewProps> = ({ onAction, contacts = [] })
 
         {/* Summary stats */}
         {!loading && (
-          <div className="flex items-center gap-3 mt-2">
-            <span className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
-              <span className="text-indigo-600 dark:text-indigo-400 font-semibold">{activeItems.length}</span>
-              {' '}action{activeItems.length !== 1 ? 's' : ''} today
-            </span>
-            {completedCount > 0 && (
-              <>
-                <span className="text-zinc-300 dark:text-zinc-700">·</span>
-                <span className="text-xs text-emerald-600 dark:text-emerald-400">
-                  <Check className="mr-1" />{completedCount} done
-                </span>
-              </>
-            )}
-            {snoozedCount > 0 && (
-              <>
-                <span className="text-zinc-300 dark:text-zinc-700">·</span>
-                <span className="text-xs text-amber-600 dark:text-amber-400">
-                  <Clock className="mr-1" />{snoozedCount} snoozed
-                </span>
-              </>
-            )}
-          </div>
+          <>
+            <div className="flex items-center gap-3 mt-1">
+              <span className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
+                <span className="text-indigo-600 dark:text-indigo-400 font-semibold">{activeItems.length}</span>
+                {' '}action{activeItems.length !== 1 ? 's' : ''} today
+              </span>
+              {completedCount > 0 && (
+                <>
+                  <span className="text-zinc-300 dark:text-zinc-700">·</span>
+                  <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                    <Check className="mr-1" />{completedCount} done
+                  </span>
+                </>
+              )}
+              {snoozedCount > 0 && (
+                <>
+                  <span className="text-zinc-300 dark:text-zinc-700">·</span>
+                  <span className="text-xs text-amber-600 dark:text-amber-400">
+                    <Clock className="mr-1" />{snoozedCount} snoozed
+                  </span>
+                </>
+              )}
+            </div>
+            <p className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-1">
+              Relationships that need your attention
+            </p>
+          </>
         )}
       </div>
 

--- a/src/utils/contactInitial.ts
+++ b/src/utils/contactInitial.ts
@@ -1,0 +1,38 @@
+// ============================================
+// CONTACT INITIAL
+// Unicode-safe initial extraction for avatar badges.
+//
+// Display names in Pulse can legitimately contain leading punctuation,
+// emoji, or symbols (e.g. `{Lucca} Messana`, `#BAL - Check Balance`,
+// `🎉 Party`). `name.charAt(0)` renders the literal `{`/`#`/emoji surrogate,
+// which looks broken in a circular avatar.
+//
+// This helper scans for the first Unicode letter and returns its uppercase
+// form. If no letter is found, it falls back to the first non-whitespace
+// char, and finally to `?` so the avatar never renders empty.
+//
+// DO NOT use this for the rendered name — display names stay verbatim
+// (see MEMORY: "Pulse Contact Name Braces"). This is purely the avatar
+// initial logic.
+// ============================================
+
+export function getContactInitial(name: string | null | undefined): string {
+  if (!name) return '?';
+
+  // `\p{L}` matches any Unicode letter — Latin, Cyrillic, CJK, etc.
+  // The `u` flag is required for Unicode property escapes.
+  const letterMatch = name.match(/\p{L}/u);
+  if (letterMatch) {
+    return letterMatch[0].toUpperCase();
+  }
+
+  // No letter at all (e.g. `#### marker`, `🎉 Party` without trailing letters
+  // already covered above, or pure punctuation). Fall back to first
+  // non-whitespace char so the badge is non-empty.
+  const nonWhitespace = name.match(/\S/);
+  if (nonWhitespace) {
+    return nonWhitespace[0];
+  }
+
+  return '?';
+}


### PR DESCRIPTION
- Today: empty state previews 6 feed types; drop duplicated H2
- People: always-visible action icons with aria-labelledby+sr-only pattern
- People: Unicode-safe initials (fix {Lucca} Messana, #BAL avatars)
- People: auto-fill grid; sidebar Alerts uses warning tokens
- Circles: promoted unsorted banner when >50% uncircled (Preview groups / Skip for now)
- Circles: rename "Auto-detect" CTA to "Group by company"
- Circles: replace window.alert with inline "No groups to suggest yet" notice
- Circles: demote "Accept all N" in AI suggestions banner
- Add getContactInitial helper (\p{L}/u scan, uppercase, punctuation/emoji-safe)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
