### PR TITLE
fix(dashboard): silence calendar noise + add decisions.decided_at

### DIFF
--- a/src/components/Dashboard/QuickScheduler.tsx
+++ b/src/components/Dashboard/QuickScheduler.tsx
@@ -95,8 +95,14 @@ const QuickScheduler: React.FC<QuickSchedulerProps> = ({ onEventCreated }) => {
         setGoogleEvents(events);
       }
     } catch (error) {
-      // Only log error if not aborted
-      if (!signal?.aborted && error instanceof Error && error.name !== 'AbortError') {
+      // Only log error if not aborted, and skip the expected "not connected" case
+      // (session.connectedProviders.google can be stale after token revocation/sign-out)
+      if (
+        !signal?.aborted &&
+        error instanceof Error &&
+        error.name !== 'AbortError' &&
+        (error as { code?: string }).code !== 'GOOGLE_CALENDAR_NOT_CONNECTED'
+      ) {
         console.error('Failed to load Google Calendar events:', error);
       }
     } finally {

--- a/supabase/migrations/20260524000001_add_decided_at_to_decisions.sql
+++ b/supabase/migrations/20260524000001_add_decided_at_to_decisions.sql
@@ -1,0 +1,30 @@
+-- Add decided_at to public.decisions.
+--
+-- The application code (src/services/decisionService.ts, DecisionVelocityTile,
+-- decisionAnalyticsService, channelExportService, types.ts) has always written
+-- and read a `decided_at` column on `public.decisions`, but the column was
+-- never present in the live schema. Every write succeeded silently (PostgREST
+-- ignores unknown keys on update? no — it returns 400; the writes were also
+-- failing, just nobody noticed) and every read returned 400 Bad Request,
+-- including the Dashboard's Decision Velocity tile on first load.
+--
+-- The closest existing columns are `resolved_at` (set on any resolution,
+-- not just status='decided') and `consensus_reached_at` (set only on
+-- consensus). Neither is a clean substitute, so we add the column the code
+-- expects and backfill from `resolved_at` where status='decided'.
+
+ALTER TABLE public.decisions
+  ADD COLUMN IF NOT EXISTS decided_at timestamptz;
+
+UPDATE public.decisions
+   SET decided_at = resolved_at
+ WHERE status = 'decided'
+   AND decided_at IS NULL
+   AND resolved_at IS NOT NULL;
+
+-- DecisionVelocityTile filters by workspace_id + status + decided_at range
+-- and orders by decided_at; a partial index on decided decisions keeps that
+-- query plan tight as the table grows.
+CREATE INDEX IF NOT EXISTS idx_decisions_workspace_decided_at
+  ON public.decisions (workspace_id, decided_at)
+  WHERE status = 'decided';


### PR DESCRIPTION
Two unrelated first-load errors observed on a Pulse load:

1) `console.error('Failed to load Google Calendar events: …
   GOOGLE_CALENDAR_NOT_CONNECTED')` — QuickScheduler already
   skips the load when `session.connectedProviders.google` is
   falsy, but the flag and the actual token go out of sync after
   sign-out / revocation, so `googleCalendarService.getValidToken`
   throws this expected sentinel and the catch block logs it like
   a real failure. Treat it the same way AbortError is treated.

2) `GET /rest/v1/decisions?…&decided_at=gte.…` → 400 Bad Request.
   DecisionVelocityTile, decisionService.finalizeDecision, the
   auto-archive query, decisionAnalyticsService, channelExportService
   and types.ts all reference `decisions.decided_at`, but the column
   was never present in the live schema (closest existing columns:
   `resolved_at`, `consensus_reached_at` — neither a clean substitute).
   Add the column the code expects and backfill from `resolved_at`
   where status='decided' (2/2 rows backfilled in pulse-chat). Also
   adds a partial index matching the velocity tile's query shape.

Schema change already applied to pulse-chat (ucaeuszgoihoyrvhewxk).

contacts.last_contacted_at 400 (Team Radar Coverage Gaps) is
NOT fixed here — that needs a design call on whether to add the
column with a backfill source (messages? emails? calls?), swap
to `last_synced` as a proxy, or no-op the feature. Tracked
separately.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
