### PR TITLE
polish(glimpse): impeccable critique pass — clarify, quieter, distill, polish

### DIFF
--- a/src/components/Glimpse/Glimpse.css
+++ b/src/components/Glimpse/Glimpse.css
@@ -691,6 +691,19 @@
   max-width: 65ch;
 }
 
+/* Card caption — lives inside the .gl-summary block as a quieter sub-line
+   when both AI summary and user caption exist. Italic + cloth color is the
+   only differentiator from the summary text above it. No side stripe, no
+   separator rule; the typographic shift is enough. */
+.gl-card-caption {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--gl-ink-cloth);
+  font-style: italic;
+  max-width: 65ch;
+}
+
 .gl-summary-skeleton {
   display: flex;
   flex-direction: column;
@@ -1009,6 +1022,16 @@
   max-width: 65ch;
 }
 
+/* Topics live inside the transcript disclosure now — give them a small
+   gap from the summary line above and a slightly larger gap from the
+   transcript prose below. */
+.gl-transcript .gl-topics {
+  margin: 10px 0 0;
+}
+.gl-transcript .gl-topics + p {
+  margin-top: 8px;
+}
+
 /* Footer */
 .gl-card-footer {
   display: flex;
@@ -1089,7 +1112,22 @@
   background: transparent;
   color: var(--gl-ink-fog);
   cursor: pointer;
-  transition: all var(--gl-fast) var(--gl-ease);
+  /* Hidden at rest — the dashed-border affordance is visual chrome that
+     doesn't earn its place on every card. Reveal on card hover or button
+     focus; touch devices keep it semi-visible (no hover available). */
+  opacity: 0;
+  transition: opacity var(--gl-fast) var(--gl-ease),
+              border-color var(--gl-fast) var(--gl-ease),
+              color var(--gl-fast) var(--gl-ease);
+}
+
+.gl-card:hover .gl-reaction-add,
+.gl-reaction-add:focus-visible {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .gl-reaction-add { opacity: 0.7; }
 }
 
 .gl-reaction-add:hover {

--- a/src/components/Glimpse/Glimpse.css
+++ b/src/components/Glimpse/Glimpse.css
@@ -2120,6 +2120,137 @@
 }
 
 /* ============================================
+   DRAFT PANEL (AI reply draft, single longer-form)
+   Floating panel anchored bottom-right. Consumes gl-* tokens directly
+   rather than raw Tailwind / hardcoded zinc — token consolidation
+   pass 2026-05-21.
+   ============================================ */
+.gl-draft-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--gl-border);
+  background: var(--gl-surface);
+  color: var(--gl-ink);
+}
+
+.video-vox-mode.dark .gl-draft-panel {
+  background: var(--gl-canvas);
+  backdrop-filter: blur(20px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.50);
+}
+
+.gl-draft-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.gl-draft-panel-tone {
+  font-family: var(--gl-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gl-ink-cloth);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gl-draft-panel-textarea {
+  width: 100%;
+  resize: none;
+  border-radius: 10px;
+  border: 1px solid var(--gl-border);
+  background: var(--gl-surface-soft);
+  padding: 12px;
+  font-family: var(--gl-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--gl-ink);
+  outline: none;
+  transition: border-color var(--gl-fast) var(--gl-ease),
+              box-shadow var(--gl-fast) var(--gl-ease);
+}
+
+.gl-draft-panel-textarea:focus {
+  border-color: var(--gl-rose);
+  box-shadow: 0 0 0 3px var(--gl-accent-soft);
+}
+
+.gl-draft-panel-next {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--gl-ink-cloth);
+}
+
+.gl-draft-panel-next-tag {
+  font-family: var(--gl-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--gl-rose-deep);
+  margin-right: 6px;
+}
+
+.video-vox-mode.dark .gl-draft-panel-next-tag {
+  color: var(--gl-rose-bright);
+}
+
+.gl-draft-panel-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Floating dismiss button — small X in a circle. Shared by the draft panel
+   header and the smart-replies floating overlay. Uses tokens, not hardcoded
+   zinc / rgba. */
+.gl-floating-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--gl-border);
+  background: var(--gl-surface-soft);
+  color: var(--gl-ink-cloth);
+  cursor: pointer;
+  transition: border-color var(--gl-fast) var(--gl-ease),
+              color var(--gl-fast) var(--gl-ease),
+              background var(--gl-fast) var(--gl-ease);
+}
+
+.gl-floating-dismiss:hover {
+  border-color: var(--gl-border-strong);
+  color: var(--gl-ink);
+  background: var(--gl-surface);
+}
+
+.gl-floating-dismiss:focus-visible {
+  outline: 2px solid var(--gl-rose);
+  outline-offset: 2px;
+}
+
+/* Recipient selector — neutral avatar fallback when contact.avatarColor is
+   missing. Replaces the inline cyan #06B6D4 leak that contradicted the
+   coral-as-only-signal rule. */
+.vvb-recipient-avatar[data-fallback] {
+  background: var(--gl-surface-soft);
+  color: var(--gl-ink-cloth);
+  font-family: var(--gl-mono);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+/* ============================================
    RESPONSIVE
    ============================================ */
 @media (max-width: 480px) {

--- a/src/components/Glimpse/Glimpse.css
+++ b/src/components/Glimpse/Glimpse.css
@@ -153,6 +153,15 @@
   color: var(--gl-ink-fog);
 }
 
+/* Muted chip variant — used on the Triage Cockpit row where the summary's
+   presence already signals AI did the work, so the chip becomes redundant
+   provenance metadata. Drops the coral so the row's coral budget stays for
+   the unread dot + action-count pill. */
+.gl-ai-chip.muted {
+  background: var(--gl-surface-soft);
+  color: var(--gl-ink-cloth);
+}
+
 /* Soft acknowledgment when AI transcription has failed — never the loudest
    element on the card. */
 .gl-transcript-fail {

--- a/src/components/Glimpse/Glimpse.tsx
+++ b/src/components/Glimpse/Glimpse.tsx
@@ -239,7 +239,7 @@ const ConversationItem: React.FC<{
       <div className="gl-tc-duration">
         {conversation.lastMessageDuration
           ? formatDuration(conversation.lastMessageDuration)
-          : '—'}
+          : '·'}
       </div>
 
       <div className="gl-tc-when">
@@ -1354,7 +1354,7 @@ const Glimpse: React.FC<GlimpseProps> = ({
                 <p className="gl-tc-empty-body">
                   When someone sends a glimpse, it lands here with a transcript,
                   summary, and action items already extracted. You'll see what
-                  to watch — and what to skip — before pressing play.
+                  to watch, and what to skip, before pressing play.
                 </p>
                 <button
                   type="button"
@@ -1383,7 +1383,7 @@ const Glimpse: React.FC<GlimpseProps> = ({
                     pattern. The strip is honest visual chrome. */}
                 <div className="gl-tc-colhead" aria-hidden="true">
                   <span />
-                  <span className="gl-label">From · Signal</span>
+                  <span className="gl-label">From · Last</span>
                   <span className="gl-label">Actions</span>
                   <span className="gl-label" style={{ textAlign: 'right' }}>Length</span>
                   <span className="gl-label" style={{ textAlign: 'right' }}>When</span>

--- a/src/components/Glimpse/Glimpse.tsx
+++ b/src/components/Glimpse/Glimpse.tsx
@@ -407,13 +407,18 @@ const MessageBubble: React.FC<{
 
       {/* Summary block — the headline. Provenance chip celebrates AI success;
           processing shows a soft pending state; failure demotes to a ghost row
-          so a broken AI doesn't dominate the card. */}
+          so a broken AI doesn't dominate the card. Caption now lives INSIDE
+          the summary block (when both exist) so the card has one content
+          spine instead of two parallel paragraphs. */}
       {(hasSummary || isProcessing) && (
         <div className="gl-summary">
           {hasSummary && (
             <>
               <span className="gl-ai-chip">CLAUDE · SUMMARY</span>
               <p className="gl-summary-text">{message.summary}</p>
+              {message.caption && (
+                <p className="gl-card-caption">“{message.caption}”</p>
+              )}
             </>
           )}
           {isProcessing && !hasSummary && (
@@ -427,12 +432,7 @@ const MessageBubble: React.FC<{
         </div>
       )}
 
-      {/* Caption (when present, distinct from AI summary) */}
-      {message.caption && hasSummary && (
-        <p className="gl-summary-text" style={{ color: 'var(--gl-ink-cloth)', fontStyle: 'italic' }}>
-          “{message.caption}”
-        </p>
-      )}
+      {/* Standalone caption — only when there's no AI summary block to host it. */}
       {message.caption && !hasSummary && !isProcessing && (
         <p className="gl-summary-text">{message.caption}</p>
       )}
@@ -463,15 +463,6 @@ const MessageBubble: React.FC<{
             );
           })}
         </ul>
-      )}
-
-      {/* Topics */}
-      {topics.length > 0 && (
-        <div className="gl-topics">
-          {topics.slice(0, 6).map((topic, i) => (
-            <span key={i} className="gl-topic">{topic}</span>
-          ))}
-        </div>
       )}
 
       {/* Inline player */}
@@ -541,11 +532,27 @@ const MessageBubble: React.FC<{
         </div>
       </div>
 
-      {/* Full transcript (collapsed by default) */}
-      {message.transcript && (
+      {/* Full transcript (collapsed by default). Topics ride along inside the
+          disclosure — they're metadata, not signal, and they don't earn a
+          peer content block at rest. */}
+      {(message.transcript || topics.length > 0) && (
         <details className="gl-transcript">
-          <summary>Full transcript</summary>
-          <p>{message.transcript}</p>
+          <summary>
+            Full transcript
+            {topics.length > 0 && (
+              <span className="gl-label dim" style={{ marginLeft: 8 }}>
+                · {topics.length} {topics.length === 1 ? 'topic' : 'topics'}
+              </span>
+            )}
+          </summary>
+          {topics.length > 0 && (
+            <div className="gl-topics">
+              {topics.slice(0, 6).map((topic, i) => (
+                <span key={i} className="gl-topic">{topic}</span>
+              ))}
+            </div>
+          )}
+          {message.transcript && <p>{message.transcript}</p>}
         </details>
       )}
 

--- a/src/components/Glimpse/Glimpse.tsx
+++ b/src/components/Glimpse/Glimpse.tsx
@@ -227,9 +227,14 @@ const ConversationItem: React.FC<{
           </span>
         )}
         {hasSummary && (
-          <span className="gl-ai-chip gl-tc-ai-chip">Claude</span>
+          // Muted in triage rows: the summary IS the AI signal — a coral chip
+          // here just doubles the attention hit and busts the row's coral
+          // budget. Provenance stays via the leading-dot pattern + label.
+          <span className="gl-ai-chip muted gl-tc-ai-chip">Claude</span>
         )}
         {processing && !hasSummary && (
+          // Pending state stays loud: this is signaling active work in
+          // progress, which IS earned attention.
           <span className="gl-ai-chip pending gl-tc-ai-chip">Transcribing</span>
         )}
         {/* Absence of action items is inferred from absence of pill — no need

--- a/src/components/Glimpse/Glimpse.tsx
+++ b/src/components/Glimpse/Glimpse.tsx
@@ -677,7 +677,8 @@ const RecipientSelector: React.FC<{
           >
             <div
               className="vvb-recipient-avatar"
-              style={{ background: contact.avatarColor || '#06B6D4' }}
+              style={contact.avatarColor ? { background: contact.avatarColor } : undefined}
+              data-fallback={contact.avatarColor ? undefined : true}
             >
               {contact.name[0]}
             </div>
@@ -1900,12 +1901,7 @@ const Glimpse: React.FC<GlimpseProps> = ({
             type="button"
             onClick={() => setShowSmartReplies(false)}
             aria-label="Dismiss smart replies"
-            className="absolute -top-2 -right-2 z-10 w-6 h-6 rounded-full flex items-center justify-center"
-            style={{
-              background: isDarkMode ? 'rgba(255,255,255,0.06)' : '#f2f2f2',
-              color: isDarkMode ? '#b4b4b8' : '#52525b',
-              border: '1px solid ' + (isDarkMode ? 'rgba(255,255,255,0.10)' : 'rgba(0,0,0,0.08)'),
-            }}
+            className="gl-floating-dismiss absolute -top-2 -right-2 z-10"
           >
             <X className="w-3 h-3" />
           </button>

--- a/src/components/Glimpse/GlimpseReplyDraftPanel.tsx
+++ b/src/components/Glimpse/GlimpseReplyDraftPanel.tsx
@@ -50,36 +50,26 @@ export const GlimpseReplyDraftPanel: React.FC<GlimpseReplyDraftPanelProps> = ({
     }
   };
 
-  const tc = {
-    bg: isDarkMode ? 'bg-zinc-900' : 'bg-white',
-    border: isDarkMode ? 'border-zinc-700' : 'border-zinc-200',
-    text: isDarkMode ? 'text-white' : 'text-zinc-900',
-    textMuted: isDarkMode ? 'text-zinc-400' : 'text-zinc-600',
-    textareaBg: isDarkMode ? 'bg-zinc-950/40' : 'bg-zinc-50',
-    secondaryBtn: isDarkMode
-      ? 'border-zinc-700 text-zinc-300 hover:bg-zinc-800'
-      : 'border-zinc-200 text-zinc-700 hover:bg-zinc-50',
-  };
+  // Styles are token-based in Glimpse.css — theme context cascades from the
+  // .video-vox-mode wrapper in Glimpse.tsx, so no wrapper needed here.
+  // isDarkMode is accepted for API parity with the AI panels but unused now
+  // that we consume tokens directly.
+  void isDarkMode;
 
   return (
-    <div
-      className={`p-4 rounded-xl border ${tc.border} ${tc.bg} flex flex-col gap-3`}
-      role="region"
-      aria-label="AI reply draft"
-    >
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
+    <div className="gl-draft-panel" role="region" aria-label="AI reply draft">
+      <div className="gl-draft-panel-head">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
           <AIProvenanceChip vendor="PULSE AI" type="DRAFT" fresh />
-          <span className={`font-mono text-[10px] uppercase tracking-[0.12em] ${tc.textMuted} truncate`}>
-            tone · {draft.tone}
-          </span>
+          <span className="gl-draft-panel-tone">tone · {draft.tone}</span>
         </div>
         <button
           type="button"
           onClick={onDismiss}
-          className={`p-1.5 rounded-md ${tc.secondaryBtn}`}
+          className="gl-floating-dismiss"
           title="Dismiss draft"
           aria-label="Dismiss draft"
+          style={{ width: 28, height: 28, borderRadius: 8 }}
         >
           <X className="w-4 h-4" />
         </button>
@@ -89,34 +79,35 @@ export const GlimpseReplyDraftPanel: React.FC<GlimpseReplyDraftPanelProps> = ({
         ref={textareaRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
-        className={`w-full resize-none rounded-lg border ${tc.border} ${tc.textareaBg} ${tc.text} p-3 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-rose-500/40`}
+        className="gl-draft-panel-textarea"
         rows={4}
         aria-label="Editable draft text"
       />
 
       {draft.suggestedAction && (
-        <p className={`text-xs ${tc.textMuted}`}>
-          <span className="font-mono uppercase tracking-[0.1em] text-rose-500 mr-1.5">next</span>
+        <p className="gl-draft-panel-next">
+          <span className="gl-draft-panel-next-tag">next</span>
           {draft.suggestedAction}
         </p>
       )}
 
-      <div className="flex items-center justify-end gap-2 flex-wrap">
+      <div className="gl-draft-panel-actions">
         <button
           type="button"
           onClick={handleCopy}
-          className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border text-sm ${tc.secondaryBtn}`}
+          className="gl-action-pill"
           title="Copy draft to clipboard"
         >
-          {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+          {copied ? <Check className="icon" /> : <Copy className="icon" />}
           <span>{copied ? 'Copied' : 'Copy'}</span>
         </button>
         {onUseAsCaption && (
           <button
             type="button"
             onClick={() => onUseAsCaption(text)}
-            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-rose-500 text-white text-sm font-medium hover:bg-rose-600 transition-colors"
+            className="gl-send-btn"
             title="Open the recorder with this draft as the caption"
+            style={{ width: 'auto', padding: '10px 16px' }}
           >
             <Video className="w-4 h-4" />
             <span>Use as caption</span>

--- a/src/components/Relay/VoxModeToolbar.tsx
+++ b/src/components/Relay/VoxModeToolbar.tsx
@@ -288,11 +288,14 @@ const VoxModeToolbar: React.FC<VoxModeToolbarProps> = ({
         </button>
       )}
 
-      {/* Selection toggle — always last */}
+      {/* Selection toggle — always last. aria-label is essential here: the
+          CheckCheck glyph is unlabelled visually, so screen-reader users
+          would otherwise hear only "button" without context. */}
       <button
         type="button"
         onClick={onToggleSelection}
         title={isSelectionMode ? 'Exit selection mode' : 'Select messages'}
+        aria-label={isSelectionMode ? 'Exit selection mode' : 'Select messages'}
         className={actionBtnBase}
         style={
           isSelectionMode


### PR DESCRIPTION
## Summary

Four-step `/impeccable` pass on the Glimpse section, addressing every P0–P2 finding from the critique (which itself ran against the post-redesign state of main after PR #79).

- **clarify** — brand voice + label cleanup. Em dashes out of product copy, "Signal" jargon → "Last", aria-label on the toolbar selection toggle.
- **quieter** — coral discipline pass on the Triage Cockpit row. Per-row coral count drops from 3 to 2 (unread dot + action pill); the "Claude" provenance chip demotes to neutral via a new `.gl-ai-chip.muted` modifier. The summary's presence already signals AI did the work; the chip was redundant.
- **distill** — chat card cognitive-load reduction. Caption moves inside the `.gl-summary` block when an AI summary exists. Topics move inside the `<details>` transcript disclosure with a "· N topics" hint in the summary line. Reaction-add (the dashed-border Heart button) is hidden at rest and reveals on card hover or button focus. Card content blocks at rest: ~7 → ~4.
- **polish** — token consolidation across the AI panels and the cyan leak fix. `GlimpseReplyDraftPanel.tsx` rebuilt against `--gl-*` tokens (killed `text-white` — the `#fff` ban — plus all `bg-zinc-*` raw Tailwind and inline rgba). New `.gl-draft-panel` family + shared `.gl-floating-dismiss` (Smart Replies dismiss button uses it too). Cyan `#06B6D4` fallback in `RecipientSelector` replaced with a neutral `data-fallback` pattern mirroring `.gl-tc-avatar-fallback`.

## Expected critique-score delta

Pre-pass: **25/40** on Nielsen heuristics (see PR-context critique). Expected post-pass: **~32-34/40**. The remaining open items (per-row filters, jump-to-unread, "send another glimpse to same person") are feature work, not polish — not in this PR's scope.

## Test plan

- [x] `npx tsc --noEmit` clean on all Glimpse files
- [x] `npm run test -- --run src/services/glimpse` — 9/9 pass
- [ ] Visual: open conversations view, confirm only unread dot + action pill are coral on triage rows; Claude chip is neutral
- [ ] Visual: open chat card with summary + caption, confirm caption sits inside summary block as italic sub-line
- [ ] Visual: open chat card with topics, confirm they live inside the "Full transcript · N topics" disclosure
- [ ] Visual: hover a chat card, confirm the dashed reaction-add button only appears then
- [ ] Visual: open AI reply draft panel, confirm it uses the same neutral surface as the rest of Glimpse (no zinc, no `#fff` text)
- [ ] Visual: open recipient selector, confirm contacts without `avatarColor` show neutral surface-soft + mono initial (no cyan)
- [ ] a11y: screen reader on the toolbar selection toggle now announces "Select messages" / "Exit selection mode" instead of a bare "button"

🤖 Generated with [Claude Code](https://claude.com/claude-code)