### PR TITLE
refactor(contacts): distill tag dots and lead-grade badges to neutral

### DIFF
--- a/src/components/contacts/Contacts.css
+++ b/src/components/contacts/Contacts.css
@@ -774,30 +774,8 @@
   color: #a8a29e;
 }
 
-/* Lead Grade Badges - Light Mode adjustments */
-.light-mode .contacts-node-lead.A,
-[data-theme="light"] .contacts-node-lead.A,
-:root:not(.dark) .contacts-node-lead.A {
-  background: rgba(16, 185, 129, 0.12);
-}
-
-.light-mode .contacts-node-lead.B,
-[data-theme="light"] .contacts-node-lead.B,
-:root:not(.dark) .contacts-node-lead.B {
-  background: rgba(59, 130, 246, 0.12);
-}
-
-.light-mode .contacts-node-lead.C,
-[data-theme="light"] .contacts-node-lead.C,
-:root:not(.dark) .contacts-node-lead.C {
-  background: rgba(234, 179, 8, 0.12);
-}
-
-.light-mode .contacts-node-lead.D,
-[data-theme="light"] .contacts-node-lead.D,
-:root:not(.dark) .contacts-node-lead.D {
-  background: rgba(107, 114, 128, 0.12);
-}
+/* Lead Grade Badges — light/dark cascade handled by var(--pulse-surface-raised)
+   in the base rule above. No per-mode overrides needed. */
 
 /* Scrollbar - Light Mode */
 .light-mode .contacts-container ::-webkit-scrollbar-thumb,
@@ -1537,22 +1515,28 @@
 .contacts-node-health-trend.up { color: var(--cnt-status-online); }
 .contacts-node-health-trend.down { color: var(--cnt-status-busy); }
 
-/* Lead Grade Badge */
+/* Lead Grade Badge — neutral surface, hierarchy via weight + opacity.
+   The previous A=emerald / B=blue / C=yellow / D=grey palette violated
+   the Status-Stays-Status rule (lead grade is a numeric quality, not a
+   state) and shipped four-color confetti on every grid view. Mono
+   labels + weight stepping carry the hierarchy without color noise. */
 .contacts-node-lead {
   position: absolute;
   top: 16px;
   right: 16px;
   padding: 4px 8px;
   border-radius: 6px;
+  font-family: var(--pulse-font-mono);
   font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.08em;
+  background: var(--pulse-surface-raised);
+  color: var(--pulse-ink);
 }
 
-.contacts-node-lead.A { background: rgba(16, 185, 129, 0.2); color: #10b981; }
-.contacts-node-lead.B { background: rgba(59, 130, 246, 0.2); color: #3b82f6; }
-.contacts-node-lead.C { background: rgba(234, 179, 8, 0.2); color: #eab308; }
-.contacts-node-lead.D { background: rgba(107, 114, 128, 0.2); color: #6b7280; }
+.contacts-node-lead.A { font-weight: 700; }
+.contacts-node-lead.B { font-weight: 600; }
+.contacts-node-lead.C { font-weight: 500; opacity: 0.75; }
+.contacts-node-lead.D { font-weight: 500; opacity: 0.5; }
 
 /* Quick Actions on Hover */
 .contacts-node-actions {

--- a/src/components/contacts/ContactsRedesigned.tsx
+++ b/src/components/contacts/ContactsRedesigned.tsx
@@ -112,11 +112,16 @@ const SMART_LISTS: SmartListConfig[] = [
   { id: 'recent_contacts', label: 'Recent', Icon: Zap },
 ];
 
+// Tags are user-applied labels, not state. The previous CRM-Kanban
+// palette (blue/green/purple/cyan) violated the Status-Stays-Status
+// rule and reintroduced the Salesforce reflex PRODUCT.md anti-references
+// explicitly reject. Label text now carries identity; the dot reflects
+// selection state via coral.
 const TAGS = [
-  { id: 'prospect', label: 'Prospect', activeColor: '#3b82f6' },
-  { id: 'customer', label: 'Customer', activeColor: '#10b981' },
-  { id: 'partner', label: 'Partner', activeColor: '#a855f7' },
-  { id: 'vendor', label: 'Vendor', activeColor: '#06b6d4' },
+  { id: 'prospect', label: 'Prospect' },
+  { id: 'customer', label: 'Customer' },
+  { id: 'partner', label: 'Partner' },
+  { id: 'vendor', label: 'Vendor' },
 ];
 
 // ============================================
@@ -296,7 +301,11 @@ const Sidebar: React.FC<SidebarProps> = ({
             <div className="contacts-filter-btn-content">
               <div
                 className="contacts-tag-dot"
-                style={{ backgroundColor: isActive ? tag.activeColor : 'currentColor' }}
+                style={{
+                  backgroundColor: isActive
+                    ? 'var(--pulse-rose)'
+                    : 'var(--pulse-ink-3)',
+                }}
               />
               <span className="contacts-filter-btn-label">{tag.label}</span>
             </div>


### PR DESCRIPTION
## Summary

Action 2 of the impeccable Contacts critique — **`/impeccable distill`** on the two CRM-flavored color systems that violated the Status-Stays-Status rule.

### Tag dots
The `TAGS` array hardcoded `activeColor: '#3b82f6' / '#10b981' / '#a855f7' / '#06b6d4'` (prospect=blue, customer=green, partner=purple, vendor=cyan). Tags are user-applied **labels**, not state — painting them in CRM-Kanban primaries is the Salesforce reflex PRODUCT.md anti-references explicitly reject.

- Drop `activeColor` from all four TAGS entries.
- Dot renders in `var(--pulse-ink-3)` at rest, `var(--pulse-rose)` when selected.
- Label text carries identity.

### Lead-grade badges (A/B/C/D)
The badges painted `.A` in emerald, `.B` in blue, `.C` in yellow, `.D` in grey — four out-of-system colors shipping on every NodeCard. Lead grade is a numeric quality, not a state.

- Unified neutral background: `var(--pulse-surface-raised)`.
- Mono label treatment (`var(--pulse-font-mono)`, tracked 0.08em).
- Quality conveyed via font-weight: A=700, B=600, C=500@0.75 opacity, D=500@0.5 opacity.
- Deleted the four light-mode override blocks; the base rule now uses pulse tokens, so light/dark cascade is automatic (–22 lines).

### Why it matters
A 30-contact People grid no longer ships four-color confetti. The Coral budget on People is now reserved for actual signal (selection, unread, alerts). One grid view at rest should be readable as quiet rhythm, not a kanban color party.

Net **–7 lines** but the visual delta is larger than the diff suggests — every grid view and the entire tag sidebar quiet down.

## Test plan
- [ ] Vercel preview loads
- [ ] People grid view: lead-grade badges A/B/C/D all neutral (no green/blue/yellow/grey palette)
- [ ] A grade visually distinct from D via weight + opacity (A bolder, D faded)
- [ ] Tag-dot sidebar: dots are subdued grey at rest, coral when selected
- [ ] Selecting a Tag still filters the list correctly
- [ ] Selecting a lead grade in Saved Filters still works
- [ ] Both light and dark mode tested

## Follow-ups (later critique Actions)
- Action 3 — `/impeccable colorize` on the orange alerts banner + yellow duplicates banner
- Action 4 — AI provenance chips on ContactDetail / MeetingPrepCard / RelationshipHealthCard
- Action 5 — Drop the gold VIP gradient (duplicate of Smart List)

🤖 Generated with [Claude Code](https://claude.com/claude-code)