### PR TITLE
refactor(contacts): colorize alerts and duplicates banners onto system

### DIFF
--- a/src/components/contacts/ContactsRedesigned.tsx
+++ b/src/components/contacts/ContactsRedesigned.tsx
@@ -314,22 +314,32 @@ const Sidebar: React.FC<SidebarProps> = ({
       })}
     </div>
 
-    {/* Alerts Banner */}
+    {/* Alerts Banner — coral signals urgency per Coral-As-Signal.
+        The previous orange+yellow gradient was pre-Coral-Cockpit
+        leftover (project_pulse_relay_css_legacy.md) and shipped a hue
+        that exists nowhere else in Pulse. Alerts are exactly what
+        coral was reserved for. */}
     {alertCount > 0 && (
       <div className="contacts-sidebar-section" style={{ paddingTop: 0 }}>
         <button
           onClick={onViewAlerts}
-          className="contacts-filter-btn active"
+          className="contacts-filter-btn"
           style={{
-            background: 'linear-gradient(135deg, rgba(249, 115, 22, 0.1), rgba(234, 179, 8, 0.1))',
-            border: '1px solid rgba(249, 115, 22, 0.2)',
+            background: 'var(--pulse-rose-soft)',
+            border: '1px solid var(--pulse-rose-soft)',
           }}
         >
           <div className="contacts-filter-btn-content">
-            <div className="contacts-filter-btn-icon" style={{ background: 'rgba(249, 115, 22, 0.2)' }}>
+            <div
+              className="contacts-filter-btn-icon"
+              style={{ background: 'var(--pulse-rose-soft)', color: 'var(--pulse-rose)' }}
+            >
               <Bell />
             </div>
-            <span className="contacts-filter-btn-label" style={{ color: '#f97316' }}>
+            <span
+              className="contacts-filter-btn-label"
+              style={{ color: 'var(--pulse-rose-deep)' }}
+            >
               {alertCount} Alert{alertCount !== 1 ? 's' : ''}
             </span>
           </div>
@@ -1402,13 +1412,16 @@ export const ContactsRedesigned: React.FC<ContactsRedesignedProps> = ({
           </div>
         </div>
 
-        {/* Duplicates Alert */}
+        {/* Duplicates Alert — informational, not urgent. Neutral
+            surface with ink text reads as "FYI" instead of "fix this
+            now". The previous yellow rgba(234, 179, 8, ...) was
+            off-system and competed with coral for "urgent" meaning. */}
         {duplicates.length > 0 && (
           <div
             style={{
               padding: '12px 24px',
-              background: 'rgba(234, 179, 8, 0.1)',
-              borderBottom: '1px solid rgba(234, 179, 8, 0.2)',
+              background: 'var(--pulse-canvas-soft)',
+              borderBottom: '1px solid var(--pulse-border)',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'space-between',
@@ -1416,7 +1429,7 @@ export const ContactsRedesigned: React.FC<ContactsRedesignedProps> = ({
           >
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <Copy />
-              <span style={{ fontSize: 13, color: '#eab308' }}>
+              <span style={{ fontSize: 13, color: 'var(--pulse-ink-2)' }}>
                 {duplicates.length} potential duplicate{duplicates.length !== 1 ? 's' : ''} detected
               </span>
             </div>
@@ -1425,7 +1438,7 @@ export const ContactsRedesigned: React.FC<ContactsRedesignedProps> = ({
               style={{
                 background: 'none',
                 border: 'none',
-                color: '#eab308',
+                color: 'var(--pulse-rose)',
                 fontSize: 12,
                 fontWeight: 600,
                 cursor: 'pointer',


### PR DESCRIPTION
## Summary

Action 3 of the impeccable Contacts critique — `/impeccable colorize` on two off-system colored surfaces in ContactsRedesigned.tsx that were shipping hues that exist nowhere else in Pulse.

### Alerts sidebar banner
Orange+yellow gradient (`rgba(249, 115, 22, 0.1) → rgba(234, 179, 8, 0.1)`) with `#f97316` label. Pre-Coral-Cockpit leftover per `project_pulse_relay_css_legacy.md`. Alerts ARE high-signal — they are exactly what coral was reserved for.

- Background → `var(--pulse-rose-soft)`
- Icon → `var(--pulse-rose)`
- Label → `var(--pulse-rose-deep)`
- Removed permanent `.active` class (Bell button was always rendering as "active" regardless of panel state — misuse of the active token).

### Duplicates banner
Yellow `rgba(234, 179, 8, ...)` + `#eab308` text and CTA. Duplicates is informational, not urgent.

- Background → `var(--pulse-canvas-soft)`
- Text → `var(--pulse-ink-2)`
- "Review & Merge" CTA kept in coral — clicking it IS the actionable next step.

Net **+24 / −11 lines**. Stacked on Action 2 (PR #95); base will auto-rebase to main once #95 merges.

## Test plan
- [ ] Vercel preview loads
- [ ] When alert count > 0, sidebar banner renders coral-toned (not orange/yellow)
- [ ] Bell icon clickable, triggers `onViewAlerts`
- [ ] Duplicates banner: neutral background with grey-ink text, coral "Review & Merge" CTA
- [ ] Both banners tested in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)